### PR TITLE
RAG-005: Implement embedding client in rag-shared

### DIFF
--- a/python/rag-shared/rag_shared/embedding.py
+++ b/python/rag-shared/rag_shared/embedding.py
@@ -1,0 +1,58 @@
+"""Embedding client wrapping sentence-transformers."""
+
+from sentence_transformers import SentenceTransformer
+
+
+class EmbeddingClient:
+    """
+    Client for generating text embeddings using sentence-transformers.
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the sentence-transformers model to load.
+    """
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
+        """
+        Initialize the embedding client.
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the sentence-transformers model to load.
+        """
+        self._model = SentenceTransformer(model_name)
+
+    def encode(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
+        """
+        Encode texts into embedding vectors.
+
+        Parameters
+        ----------
+        texts : list[str]
+            List of texts to encode.
+        batch_size : int
+            Batch size for encoding.
+
+        Returns
+        -------
+        list[list[float]]
+            List of embedding vectors.
+        """
+        if not texts:
+            return []
+        embeddings = self._model.encode(texts, batch_size=batch_size)
+        return [vec.tolist() for vec in embeddings]
+
+    @property
+    def dimension(self) -> int:
+        """
+        Return the embedding dimension.
+
+        Returns
+        -------
+        int
+            Dimension of the embedding vectors.
+        """
+        return self._model.get_sentence_embedding_dimension()  # type: ignore[return-value]

--- a/python/rag-shared/tests/test_embedding.py
+++ b/python/rag-shared/tests/test_embedding.py
@@ -1,0 +1,75 @@
+"""Tests for embedding client."""
+
+import pytest
+
+from rag_shared.embedding import EmbeddingClient
+
+DIMENSION = 384
+
+
+@pytest.fixture(scope="module")
+def client() -> EmbeddingClient:
+    """
+    Return a shared EmbeddingClient instance.
+
+    Returns
+    -------
+    EmbeddingClient
+        A client loaded with all-MiniLM-L6-v2.
+    """
+    return EmbeddingClient("all-MiniLM-L6-v2")
+
+
+def test_encode_single(client: EmbeddingClient) -> None:
+    """
+    Test encoding a single string returns one vector.
+
+    Parameters
+    ----------
+    client : EmbeddingClient
+        The embedding client fixture.
+    """
+    result = client.encode(["hello"])
+    assert len(result) == 1
+    assert len(result[0]) == DIMENSION
+    assert all(isinstance(v, float) for v in result[0])
+
+
+def test_encode_empty(client: EmbeddingClient) -> None:
+    """
+    Test encoding an empty list returns empty list.
+
+    Parameters
+    ----------
+    client : EmbeddingClient
+        The embedding client fixture.
+    """
+    result = client.encode([])
+    assert result == []
+
+
+def test_encode_batch(client: EmbeddingClient) -> None:
+    """
+    Test encoding multiple strings with small batch size.
+
+    Parameters
+    ----------
+    client : EmbeddingClient
+        The embedding client fixture.
+    """
+    texts = [f"text {i}" for i in range(10)]
+    result = client.encode(texts, batch_size=3)
+    assert len(result) == 10
+    assert all(len(vec) == DIMENSION for vec in result)
+
+
+def test_dimension(client: EmbeddingClient) -> None:
+    """
+    Test dimension property matches encode output.
+
+    Parameters
+    ----------
+    client : EmbeddingClient
+        The embedding client fixture.
+    """
+    assert client.dimension == DIMENSION


### PR DESCRIPTION
## Summary
- `EmbeddingClient` class in `rag_shared/embedding.py` wrapping `sentence-transformers`
- `encode(texts, batch_size)` returns `list[list[float]]`, handles empty input
- `dimension` property returns embedding vector size (384 for all-MiniLM-L6-v2)
- Full test coverage: single encode, empty list, batch encode, dimension check

**Depends on**: #30 (RAG-004)

Closes #5

## Test plan
- [x] `uv run pytest -v` — 5 tests pass (4 embedding + 1 version)
- [x] `embedding.py` at 100% coverage
- [x] ruff, mypy strict, numpydoc all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)