### PR TITLE
feat: implement App diagnostics for lib-embedding and lib-orm

### DIFF
--- a/python/lib-embedding/lib_embedding/__init__.py
+++ b/python/lib-embedding/lib_embedding/__init__.py
@@ -1,3 +1,6 @@
 """Embedding client library for RAG system."""
 
 __version__ = "0.1.0"
+
+from lib_embedding.embedding import EmbeddingClient
+from lib_embedding.settings import EmbeddingSettings

--- a/python/lib-embedding/lib_embedding/app.py
+++ b/python/lib-embedding/lib_embedding/app.py
@@ -1,5 +1,6 @@
 """Application module for lib-embedding."""
 
+from lib_embedding.embedding import EmbeddingClient
 from lib_embedding.task_inputs import task_inputs
 
 
@@ -10,7 +11,9 @@ class App:
         """
         Run diagnostics.
 
-        Load the embedding model and print its configuration.
+        Load the embedding model and print its name and dimension.
         """
-        print(f"Embedding model: {task_inputs.embedding_model}")
-        print(f"Vector dimension: {task_inputs.vector_dim}")
+        model_name = task_inputs.embedding_model
+        print(f"Loading model: {model_name}")
+        client = EmbeddingClient(model_name)
+        print(f"Model: {model_name} ({client.dimension} dims)")

--- a/python/lib-embedding/lib_embedding/task_inputs.py
+++ b/python/lib-embedding/lib_embedding/task_inputs.py
@@ -7,7 +7,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class TaskInputs(BaseSettings):
     """Task inputs for lib-embedding diagnostics."""
 
-    model_config = SettingsConfigDict(cli_parse_args=True)
+    model_config = SettingsConfigDict(cli_parse_args=True, cli_ignore_unknown_args=True)
 
     embedding_model: str = Field(
         default="all-MiniLM-L6-v2",

--- a/python/lib-embedding/tests/test_app.py
+++ b/python/lib-embedding/tests/test_app.py
@@ -1,0 +1,35 @@
+"""Tests for lib-embedding App diagnostics."""
+
+import pytest
+
+from lib_embedding.app import App
+
+
+@pytest.fixture(scope="module")
+def app() -> App:
+    """
+    Return a shared App instance.
+
+    Returns
+    -------
+    App
+        An App instance for diagnostics.
+    """
+    return App()
+
+
+def test_run_prints_model_info(app: App, capsys: pytest.CaptureFixture[str]) -> None:
+    """
+    Test that App.run() prints model name and dimension.
+
+    Parameters
+    ----------
+    app : App
+        The app fixture.
+    capsys : pytest.CaptureFixture[str]
+        Pytest capture fixture.
+    """
+    app.run()
+    captured = capsys.readouterr()
+    assert "all-MiniLM-L6-v2" in captured.out
+    assert "384 dims" in captured.out

--- a/python/lib-embedding/tests/test_init.py
+++ b/python/lib-embedding/tests/test_init.py
@@ -1,0 +1,9 @@
+"""Tests for lib-embedding public API."""
+
+from lib_embedding import EmbeddingClient, EmbeddingSettings
+
+
+def test_exports() -> None:
+    """Test that key classes are importable from the package root."""
+    assert EmbeddingClient is not None
+    assert EmbeddingSettings is not None

--- a/python/lib-orm/lib_orm/__init__.py
+++ b/python/lib-orm/lib_orm/__init__.py
@@ -1,3 +1,7 @@
 """Database and ORM library for RAG system."""
 
 __version__ = "0.1.0"
+
+from lib_orm.db import get_async_engine, get_async_session, get_async_session_factory
+from lib_orm.models import Base, DocumentChunk
+from lib_orm.settings import DbSettings

--- a/python/lib-orm/lib_orm/app.py
+++ b/python/lib-orm/lib_orm/app.py
@@ -1,5 +1,10 @@
 """Application module for lib-orm."""
 
+import asyncio
+
+from sqlalchemy import text
+
+from lib_orm.db import get_async_engine
 from lib_orm.task_inputs import task_inputs
 
 
@@ -10,6 +15,28 @@ class App:
         """
         Run diagnostics.
 
-        Verify DB connectivity and print configuration.
+        Verify DB connectivity and print connection status.
         """
-        print(f"Database URL: {task_inputs.db_url}")
+        db_url = task_inputs.db_url
+        print(f"Database URL: {db_url}")
+        asyncio.run(self._check_db(db_url))
+
+    @staticmethod
+    async def _check_db(url: str) -> None:
+        """
+        Check database connectivity.
+
+        Parameters
+        ----------
+        url : str
+            Database connection URL.
+        """
+        engine = get_async_engine(url)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            print("DB connection: OK")
+        except Exception as exc:  # noqa: BLE001
+            print(f"DB connection: FAILED ({exc})")
+        finally:
+            await engine.dispose()

--- a/python/lib-orm/lib_orm/task_inputs.py
+++ b/python/lib-orm/lib_orm/task_inputs.py
@@ -7,7 +7,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class TaskInputs(BaseSettings):
     """Task inputs for lib-orm diagnostics."""
 
-    model_config = SettingsConfigDict(cli_parse_args=True)
+    model_config = SettingsConfigDict(cli_parse_args=True, cli_ignore_unknown_args=True)
 
     db_url: str = Field(
         default="postgresql+asyncpg://rag:rag@localhost:5432/rag",

--- a/python/lib-orm/tests/test_app.py
+++ b/python/lib-orm/tests/test_app.py
@@ -1,0 +1,80 @@
+"""Tests for lib-orm App diagnostics."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib_orm.app import App
+
+
+def test_run_db_ok(capsys: pytest.CaptureFixture[str]) -> None:
+    """
+    Test that App.run() prints OK when DB is reachable.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture[str]
+        Pytest capture fixture.
+    """
+
+    @asynccontextmanager
+    async def _fake_connect() -> AsyncGenerator[Any]:
+        """
+        Yield a mock connection.
+
+        Yields
+        ------
+        Any
+            A mock connection object.
+        """
+        yield AsyncMock()
+
+    mock_engine = AsyncMock()
+    mock_engine.connect = _fake_connect
+    mock_engine.dispose = AsyncMock()
+
+    with patch("lib_orm.app.get_async_engine", return_value=mock_engine):
+        app = App()
+        app.run()
+
+    captured = capsys.readouterr()
+    assert "DB connection: OK" in captured.out
+
+
+def test_run_db_failed(capsys: pytest.CaptureFixture[str]) -> None:
+    """
+    Test that App.run() prints FAILED when DB is unreachable.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture[str]
+        Pytest capture fixture.
+    """
+
+    @asynccontextmanager
+    async def _failing_connect() -> AsyncGenerator[Any]:
+        """
+        Raise ConnectionRefusedError before yielding.
+
+        Yields
+        ------
+        Any
+            Never yields; raises before reaching yield.
+        """
+        raise ConnectionRefusedError("Connection refused")
+        yield  # pragma: no cover
+
+    mock_engine = AsyncMock()
+    mock_engine.connect = _failing_connect
+    mock_engine.dispose = AsyncMock()
+
+    with patch("lib_orm.app.get_async_engine", return_value=mock_engine):
+        app = App()
+        app.run()
+
+    captured = capsys.readouterr()
+    assert "DB connection: FAILED" in captured.out
+    assert "Connection refused" in captured.out

--- a/python/lib-orm/tests/test_init.py
+++ b/python/lib-orm/tests/test_init.py
@@ -1,0 +1,11 @@
+"""Tests for lib-orm public API."""
+
+from lib_orm import Base, DbSettings, DocumentChunk, get_async_engine
+
+
+def test_exports() -> None:
+    """Test that key classes are importable from the package root."""
+    assert Base is not None
+    assert DocumentChunk is not None
+    assert DbSettings is not None
+    assert get_async_engine is not None

--- a/python/lib-schemas/lib_schemas/task_inputs.py
+++ b/python/lib-schemas/lib_schemas/task_inputs.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class TaskInputs(BaseSettings):
     """Task inputs for lib-schemas diagnostics."""
 
-    model_config = SettingsConfigDict(cli_parse_args=True)
+    model_config = SettingsConfigDict(cli_parse_args=True, cli_ignore_unknown_args=True)
 
 
 task_inputs = TaskInputs()  # type: ignore[call-arg, unused-ignore]


### PR DESCRIPTION
## Summary
- **lib-embedding** `App.run()`: loads the embedding model, prints model name and dimension
- **lib-orm** `App.run()`: tests DB connectivity with async engine, prints OK/FAILED with error details
- Export key classes from `__init__.py` in both packages (e.g. `from lib_orm import DocumentChunk`)
- Add `cli_ignore_unknown_args=True` to all `task_inputs.py` to fix pytest CLI arg conflict
- Add `.coverage` and `htmlcov/` to `.gitignore`

Closes #8

## Test plan
- [x] lib-embedding: 8 tests pass (app diagnostics, embedding, settings, exports)
- [x] lib-orm: 11 tests pass (app OK/FAILED, db, models, settings, exports)
- [x] ruff check + format + mypy strict — pass in both packages
- [x] pre-commit hooks pass (numpydoc, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)