### PR TITLE
feat(rag-embedder): implement batch writer for pgvector

### DIFF
--- a/python/rag-embedder/pyproject.toml
+++ b/python/rag-embedder/pyproject.toml
@@ -19,6 +19,7 @@ main = "rag_embedder.main:main"
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "pytest-asyncio>=0.25.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.14.4",
     "mypy>=1.18.2",
@@ -68,6 +69,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/python/rag-embedder/rag_embedder/writer.py
+++ b/python/rag-embedder/rag_embedder/writer.py
@@ -1,0 +1,58 @@
+"""Batch writer for inserting chunk embeddings into pgvector."""
+
+from lib_orm.models import DocumentChunk
+from lib_schemas.schemas import ChunkWithEmbedding
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def write_chunks(session: AsyncSession, chunks: list[ChunkWithEmbedding]) -> int:
+    """
+    Batch-insert chunks with embeddings into the database.
+
+    Uses upsert semantics: existing rows matching ``(document_name, chunk_index)``
+    are updated; new rows are inserted.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active async database session.
+    chunks : list[ChunkWithEmbedding]
+        Chunks with embeddings to write.
+
+    Returns
+    -------
+    int
+        Number of rows affected (inserted or updated).
+    """
+    if not chunks:
+        return 0
+
+    count = 0
+    for chunk in chunks:
+        result = await session.execute(
+            select(DocumentChunk).where(
+                DocumentChunk.document_name == chunk.document_name,
+                DocumentChunk.chunk_index == chunk.chunk_index,
+            )
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing is not None:
+            existing.content = chunk.content
+            existing.metadata_ = chunk.metadata
+            existing.embedding = chunk.embedding
+        else:
+            session.add(
+                DocumentChunk(
+                    document_name=chunk.document_name,
+                    chunk_index=chunk.chunk_index,
+                    content=chunk.content,
+                    metadata_=chunk.metadata,
+                    embedding=chunk.embedding,
+                )
+            )
+        count += 1
+
+    await session.flush()
+    return count

--- a/python/rag-embedder/tests/test_writer.py
+++ b/python/rag-embedder/tests/test_writer.py
@@ -1,0 +1,121 @@
+"""Tests for rag-embedder batch writer."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from lib_schemas.schemas import ChunkWithEmbedding
+
+from rag_embedder.writer import write_chunks
+
+
+def _make_chunk(name: str, index: int) -> ChunkWithEmbedding:
+    """
+    Create a test ChunkWithEmbedding.
+
+    Parameters
+    ----------
+    name : str
+        Document name.
+    index : int
+        Chunk index.
+
+    Returns
+    -------
+    ChunkWithEmbedding
+        A test chunk with a dummy embedding.
+    """
+    return ChunkWithEmbedding(
+        document_name=name,
+        chunk_index=index,
+        content=f"Content for {name} chunk {index}",
+        metadata={},
+        embedding=[0.1] * 384,
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_empty_list() -> None:
+    """Test that writing an empty list returns 0."""
+    session = AsyncMock()
+    result = await write_chunks(session, [])
+    assert result == 0
+    session.flush.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_write_inserts_new_chunks() -> None:
+    """Test that new chunks are inserted via session.add."""
+    session = AsyncMock()
+    # scalar_one_or_none returns None -> new row
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    session.execute.return_value = mock_result
+
+    chunks = [_make_chunk("doc.md", 0), _make_chunk("doc.md", 1)]
+    count = await write_chunks(session, chunks)
+
+    assert count == 2
+    assert session.add.call_count == 2
+    session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_write_updates_existing_chunks() -> None:
+    """Test that existing chunks are updated in place."""
+    existing_row = MagicMock()
+    existing_row.content = "old content"
+    existing_row.metadata_ = {}
+    existing_row.embedding = [0.0] * 384
+
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing_row
+    session.execute.return_value = mock_result
+
+    chunks = [_make_chunk("doc.md", 0)]
+    count = await write_chunks(session, chunks)
+
+    assert count == 1
+    assert existing_row.content == "Content for doc.md chunk 0"
+    assert existing_row.embedding == [0.1] * 384
+    # Should NOT call session.add for updates
+    session.add.assert_not_called()
+    session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_write_five_chunks() -> None:
+    """Test inserting 5 chunks returns count of 5."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    session.execute.return_value = mock_result
+
+    chunks = [_make_chunk("doc.md", i) for i in range(5)]
+    count = await write_chunks(session, chunks)
+
+    assert count == 5
+    assert session.add.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_write_mixed_insert_and_update() -> None:
+    """Test a mix of new and existing chunks."""
+    existing_row = MagicMock()
+    existing_row.content = "old"
+    existing_row.metadata_ = {}
+    existing_row.embedding = [0.0] * 384
+
+    session = AsyncMock()
+    # First call: existing, second call: new
+    result_existing = MagicMock()
+    result_existing.scalar_one_or_none.return_value = existing_row
+    result_new = MagicMock()
+    result_new.scalar_one_or_none.return_value = None
+    session.execute.side_effect = [result_existing, result_new]
+
+    chunks = [_make_chunk("doc.md", 0), _make_chunk("doc.md", 1)]
+    count = await write_chunks(session, chunks)
+
+    assert count == 2
+    assert session.add.call_count == 1  # only the new one

--- a/python/rag-embedder/uv.lock
+++ b/python/rag-embedder/uv.lock
@@ -897,6 +897,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -970,6 +982,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -986,6 +999,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.4" },
 ]


### PR DESCRIPTION
## Summary
- Adds `rag_embedder/writer.py` with `async write_chunks(session, chunks)` function
- Upsert semantics: matches on `(document_name, chunk_index)`, updates existing or inserts new
- Returns count of rows affected, handles empty list gracefully
- Adds `pytest-asyncio` dev dependency for async test support

Closes #14

## Test plan
- [x] 5 async tests: empty list, insert new, update existing, 5 chunks, mixed insert/update
- [x] `uv run ruff check` — no violations
- [x] `uv run mypy rag_embedder/` — passes strict
- [x] `uv run pytest -v` — all tests pass
- [x] `pre-commit run` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)