### PR TITLE
feat(rag-retriever): FastAPI app factory and health endpoints

### DIFF
--- a/python/rag-retriever/rag_retriever/api.py
+++ b/python/rag-retriever/rag_retriever/api.py
@@ -1,0 +1,48 @@
+"""FastAPI application factory."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from rag_retriever.dependencies import init_dependencies, shutdown_dependencies
+from rag_retriever.routes.health import router as health_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """
+    Manage application startup and shutdown.
+
+    Parameters
+    ----------
+    app : FastAPI
+        The FastAPI application instance.
+
+    Yields
+    ------
+    None
+        Yields control to the application during its lifetime.
+    """
+    await init_dependencies()
+    yield
+    await shutdown_dependencies()
+
+
+def create_app() -> FastAPI:
+    """
+    Create and configure the FastAPI application.
+
+    Returns
+    -------
+    FastAPI
+        Configured FastAPI application with all routes registered.
+    """
+    app = FastAPI(
+        title="RAG Retriever",
+        description="Semantic search API for RAG system with pgvector",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.include_router(health_router)
+    return app

--- a/python/rag-retriever/rag_retriever/app.py
+++ b/python/rag-retriever/rag_retriever/app.py
@@ -1,5 +1,7 @@
 """Application module for rag-retriever."""
 
+import uvicorn
+
 from rag_retriever.task_inputs import task_inputs
 
 
@@ -18,4 +20,9 @@ class App:
         print(f"Database URL:    {task_inputs.db_url}")
         print(f"Embedding model: {task_inputs.embedding_model}")
         print(f"Default top_k:   {task_inputs.top_k}")
-        print("rag-retriever: server not yet implemented")
+        uvicorn.run(
+            "rag_retriever.api:create_app",
+            host=task_inputs.host,
+            port=task_inputs.port,
+            factory=True,
+        )

--- a/python/rag-retriever/rag_retriever/dependencies.py
+++ b/python/rag-retriever/rag_retriever/dependencies.py
@@ -1,0 +1,112 @@
+"""FastAPI dependency injection for database sessions and embedding client."""
+
+from collections.abc import AsyncGenerator
+
+from lib_embedding.embedding import EmbeddingClient
+from lib_orm.db import get_async_engine, get_async_session_factory
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from rag_retriever.task_inputs import task_inputs
+
+_engine: AsyncEngine | None = None
+_embedding_client: EmbeddingClient | None = None
+
+
+async def init_dependencies() -> None:
+    """
+    Initialize shared resources at application startup.
+
+    Creates the async database engine and loads the embedding model.
+    """
+    global _engine, _embedding_client  # noqa: PLW0603
+    _engine = get_async_engine(task_inputs.db_url)
+    _embedding_client = EmbeddingClient(task_inputs.embedding_model)
+
+
+async def shutdown_dependencies() -> None:
+    """Dispose of shared resources at application shutdown."""
+    global _engine, _embedding_client  # noqa: PLW0603
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+    _embedding_client = None
+
+
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
+    """
+    Yield an async database session for a single request.
+
+    Yields
+    ------
+    AsyncSession
+        An active async session that is committed on success and rolled back
+        on error.
+
+    Raises
+    ------
+    RuntimeError
+        If called before ``init_dependencies``.
+    """
+    if _engine is None:
+        msg = "Database engine not initialized"
+        raise RuntimeError(msg)
+    factory = get_async_session_factory(_engine)
+    async with factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+def get_embedding_client() -> EmbeddingClient:
+    """
+    Return the shared embedding client.
+
+    Returns
+    -------
+    EmbeddingClient
+        The pre-loaded embedding client.
+
+    Raises
+    ------
+    RuntimeError
+        If called before ``init_dependencies``.
+    """
+    if _embedding_client is None:
+        msg = "Embedding client not initialized"
+        raise RuntimeError(msg)
+    return _embedding_client
+
+
+async def check_db_health() -> bool:
+    """
+    Check whether the database is reachable.
+
+    Returns
+    -------
+    bool
+        True if ``SELECT 1`` succeeds, False otherwise.
+    """
+    if _engine is None:
+        return False
+    try:
+        async with _engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def check_model_health() -> bool:
+    """
+    Check whether the embedding model is loaded.
+
+    Returns
+    -------
+    bool
+        True if the embedding client is available.
+    """
+    return _embedding_client is not None

--- a/python/rag-retriever/rag_retriever/routes/health.py
+++ b/python/rag-retriever/rag_retriever/routes/health.py
@@ -1,0 +1,51 @@
+"""Health and readiness probe endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, Response
+
+from rag_retriever.dependencies import check_db_health, check_model_health
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """
+    Return basic health status.
+
+    Returns
+    -------
+    dict[str, str]
+        Always returns ``{"status": "ok"}``.
+    """
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def ready(response: Response) -> dict[str, Any]:
+    """
+    Check readiness of all dependencies.
+
+    Parameters
+    ----------
+    response : Response
+        FastAPI response object for setting status code.
+
+    Returns
+    -------
+    dict[str, Any]
+        Readiness status including database and model health.
+    """
+    db_ok = await check_db_health()
+    model_ok = check_model_health()
+    is_ready = db_ok and model_ok
+
+    if not is_ready:
+        response.status_code = 503
+
+    return {
+        "status": "ready" if is_ready else "not_ready",
+        "db": db_ok,
+        "model": model_ok,
+    }

--- a/python/rag-retriever/tests/test_app.py
+++ b/python/rag-retriever/tests/test_app.py
@@ -7,16 +7,19 @@ import pytest
 from rag_retriever.app import App
 
 
-def test_run_prints_config(capsys: pytest.CaptureFixture[str]) -> None:
+def test_run_starts_uvicorn(capsys: pytest.CaptureFixture[str]) -> None:
     """
-    Test that App.run() prints configuration values.
+    Test that App.run() prints config and calls uvicorn.run.
 
     Parameters
     ----------
     capsys : pytest.CaptureFixture[str]
         Pytest capture fixture.
     """
-    with patch("rag_retriever.app.task_inputs") as mock_inputs:
+    with (
+        patch("rag_retriever.app.task_inputs") as mock_inputs,
+        patch("rag_retriever.app.uvicorn") as mock_uvicorn,
+    ):
         mock_inputs.host = "0.0.0.0"
         mock_inputs.port = 8000
         mock_inputs.db_url = "postgresql+asyncpg://rag:rag@localhost:5432/rag"
@@ -30,3 +33,10 @@ def test_run_prints_config(capsys: pytest.CaptureFixture[str]) -> None:
     assert "Database URL:" in captured.out
     assert "Embedding model:" in captured.out
     assert "Default top_k:" in captured.out
+
+    mock_uvicorn.run.assert_called_once_with(
+        "rag_retriever.api:create_app",
+        host="0.0.0.0",
+        port=8000,
+        factory=True,
+    )

--- a/python/rag-retriever/tests/test_dependencies.py
+++ b/python/rag-retriever/tests/test_dependencies.py
@@ -1,0 +1,82 @@
+"""Tests for dependency injection module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rag_retriever import dependencies
+
+
+@pytest.fixture(autouse=True)
+def _reset_dependencies() -> None:
+    """Reset module-level state before each test."""
+    dependencies._engine = None
+    dependencies._embedding_client = None
+
+
+def test_get_embedding_client_not_initialized() -> None:
+    """Test that get_embedding_client raises when not initialized."""
+    with pytest.raises(RuntimeError, match="Embedding client not initialized"):
+        dependencies.get_embedding_client()
+
+
+@pytest.mark.asyncio
+async def test_get_db_session_not_initialized() -> None:
+    """Test that get_db_session raises when engine is not initialized."""
+    with pytest.raises(RuntimeError, match="Database engine not initialized"):
+        async for _session in dependencies.get_db_session():
+            pass  # pragma: no cover
+
+
+def test_check_model_health_no_client() -> None:
+    """Test model health returns False when client is None."""
+    assert dependencies.check_model_health() is False
+
+
+def test_check_model_health_with_client() -> None:
+    """Test model health returns True when client is set."""
+    dependencies._embedding_client = MagicMock()  # type: ignore[assignment]
+    assert dependencies.check_model_health() is True
+
+
+@pytest.mark.asyncio
+async def test_check_db_health_no_engine() -> None:
+    """Test DB health returns False when engine is None."""
+    result = await dependencies.check_db_health()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_db_health_connection_error() -> None:
+    """Test DB health returns False on connection error."""
+    mock_engine = MagicMock()
+    mock_conn = AsyncMock()
+    mock_conn.execute.side_effect = ConnectionRefusedError("refused")
+    mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    dependencies._engine = mock_engine
+    result = await dependencies.check_db_health()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_init_and_shutdown() -> None:
+    """Test that init and shutdown manage resources correctly."""
+    mock_engine = MagicMock()
+    mock_engine.dispose = AsyncMock()
+    mock_client = MagicMock()
+
+    with (
+        patch("rag_retriever.dependencies.get_async_engine", return_value=mock_engine),
+        patch("rag_retriever.dependencies.EmbeddingClient", return_value=mock_client),
+    ):
+        await dependencies.init_dependencies()
+
+    assert dependencies._engine is mock_engine
+    assert dependencies._embedding_client is mock_client
+
+    await dependencies.shutdown_dependencies()
+    mock_engine.dispose.assert_awaited_once()
+    assert dependencies._engine is None
+    assert dependencies._embedding_client is None

--- a/python/rag-retriever/tests/test_health.py
+++ b/python/rag-retriever/tests/test_health.py
@@ -1,0 +1,134 @@
+"""Tests for health and readiness endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from rag_retriever.api import create_app
+
+
+@pytest.fixture
+def app_no_lifespan() -> object:
+    """
+    Create a FastAPI app without running the lifespan.
+
+    Returns
+    -------
+    FastAPI
+        A FastAPI app instance for testing.
+    """
+    with patch("rag_retriever.api.lifespan") as mock_lifespan:
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _noop_lifespan(app):  # type: ignore[no-untyped-def]  # noqa: ANN001
+            yield
+
+        mock_lifespan.side_effect = _noop_lifespan
+        yield create_app()
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok(app_no_lifespan: object) -> None:
+    """
+    Test that GET /health returns status ok.
+
+    Parameters
+    ----------
+    app_no_lifespan : object
+        FastAPI app fixture without lifespan.
+    """
+    transport = ASGITransport(app=app_no_lifespan)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_ready_all_healthy(app_no_lifespan: object) -> None:
+    """
+    Test that GET /ready returns 200 when DB and model are healthy.
+
+    Parameters
+    ----------
+    app_no_lifespan : object
+        FastAPI app fixture without lifespan.
+    """
+    with (
+        patch(
+            "rag_retriever.routes.health.check_db_health",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("rag_retriever.routes.health.check_model_health", return_value=True),
+    ):
+        transport = ASGITransport(app=app_no_lifespan)  # type: ignore[arg-type]
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ready")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["db"] is True
+    assert data["model"] is True
+
+
+@pytest.mark.asyncio
+async def test_ready_db_down(app_no_lifespan: object) -> None:
+    """
+    Test that GET /ready returns 503 when DB is unreachable.
+
+    Parameters
+    ----------
+    app_no_lifespan : object
+        FastAPI app fixture without lifespan.
+    """
+    with (
+        patch(
+            "rag_retriever.routes.health.check_db_health",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch("rag_retriever.routes.health.check_model_health", return_value=True),
+    ):
+        transport = ASGITransport(app=app_no_lifespan)  # type: ignore[arg-type]
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ready")
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] == "not_ready"
+    assert data["db"] is False
+    assert data["model"] is True
+
+
+@pytest.mark.asyncio
+async def test_ready_model_not_loaded(app_no_lifespan: object) -> None:
+    """
+    Test that GET /ready returns 503 when model is not loaded.
+
+    Parameters
+    ----------
+    app_no_lifespan : object
+        FastAPI app fixture without lifespan.
+    """
+    with (
+        patch(
+            "rag_retriever.routes.health.check_db_health",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("rag_retriever.routes.health.check_model_health", return_value=False),
+    ):
+        transport = ASGITransport(app=app_no_lifespan)  # type: ignore[arg-type]
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ready")
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] == "not_ready"
+    assert data["db"] is True
+    assert data["model"] is False


### PR DESCRIPTION
## Summary
- Implements FastAPI app factory with `create_app()` and lifespan management (RAG-017)
- Adds `dependencies.py` with DI for async DB sessions and embedding client
- Creates `GET /health` (always 200) and `GET /ready` (checks DB + model, returns 503 when not ready)
- Wires `App.run()` to start uvicorn with the factory
- 13 tests pass (httpx.AsyncClient for endpoint tests, unit tests for DI module)

## Test plan
- [x] `uv run ruff check` — no violations
- [x] `uv run ruff format --check` — formatted
- [x] `uv run mypy rag_retriever/` — passes strict
- [x] `uv run pytest -v` — 13 tests pass, 81% coverage
- [x] `pre-commit run --files` — all hooks pass (including numpydoc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)