### PR TITLE
feat(rag-retriever): implement POST /search endpoint

### DIFF
--- a/python/rag-retriever/rag_retriever/api.py
+++ b/python/rag-retriever/rag_retriever/api.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 
 from rag_retriever.dependencies import init_dependencies, shutdown_dependencies
 from rag_retriever.routes.health import router as health_router
+from rag_retriever.routes.search import router as search_router
 
 
 @asynccontextmanager
@@ -45,4 +46,5 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
     app.include_router(health_router)
+    app.include_router(search_router)
     return app

--- a/python/rag-retriever/rag_retriever/routes/search.py
+++ b/python/rag-retriever/rag_retriever/routes/search.py
@@ -1,0 +1,81 @@
+"""Semantic search endpoint."""
+
+import time
+
+from fastapi import APIRouter, Depends
+from lib_embedding.embedding import EmbeddingClient
+from lib_orm.models import DocumentChunk
+from lib_schemas.schemas import SearchRequest, SearchResponse, SearchResult
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from rag_retriever.dependencies import get_db_session, get_embedding_client
+
+router = APIRouter()
+
+
+@router.post("/search")
+async def search(
+    body: SearchRequest,
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+    client: EmbeddingClient = Depends(get_embedding_client),  # noqa: B008
+) -> SearchResponse:
+    """
+    Perform semantic search over document chunks.
+
+    Embeds the query, searches pgvector using cosine distance, and returns
+    ranked results filtered by similarity threshold.
+
+    Parameters
+    ----------
+    body : SearchRequest
+        The search request with query, top_k, and similarity_threshold.
+    session : AsyncSession
+        Injected database session.
+    client : EmbeddingClient
+        Injected embedding client.
+
+    Returns
+    -------
+    SearchResponse
+        Ranked search results with timing information.
+    """
+    # Embed the query
+    t0 = time.perf_counter()
+    vectors = client.encode([body.query])
+    embedding_time_ms = (time.perf_counter() - t0) * 1000
+    query_embedding = vectors[0]
+
+    # Search pgvector using cosine distance
+    t1 = time.perf_counter()
+    similarity = (1 - DocumentChunk.embedding.cosine_distance(query_embedding)).label("similarity")
+
+    stmt = (
+        select(DocumentChunk, similarity)
+        .where(similarity >= body.similarity_threshold)
+        .order_by(similarity.desc())
+        .limit(body.top_k)
+    )
+
+    result = await session.execute(stmt)
+    rows = result.all()
+    search_time_ms = (time.perf_counter() - t1) * 1000
+
+    results = [
+        SearchResult(
+            chunk_id=row.DocumentChunk.id,
+            document_name=row.DocumentChunk.document_name,
+            content=row.DocumentChunk.content,
+            similarity_score=float(row.similarity),
+            metadata=row.DocumentChunk.metadata_,
+        )
+        for row in rows
+    ]
+
+    return SearchResponse(
+        query=body.query,
+        results=results,
+        total_results=len(results),
+        embedding_time_ms=round(embedding_time_ms, 2),
+        search_time_ms=round(search_time_ms, 2),
+    )

--- a/python/rag-retriever/tests/test_search.py
+++ b/python/rag-retriever/tests/test_search.py
@@ -1,0 +1,192 @@
+"""Tests for POST /search endpoint."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from rag_retriever.api import create_app
+from rag_retriever.dependencies import get_db_session, get_embedding_client
+
+
+def _make_app(session: AsyncMock, client: MagicMock) -> FastAPI:
+    """
+    Create a test app with overridden dependencies.
+
+    Parameters
+    ----------
+    session : AsyncMock
+        Mock database session.
+    client : MagicMock
+        Mock embedding client.
+
+    Returns
+    -------
+    FastAPI
+        App with dependency overrides.
+    """
+    with patch("rag_retriever.api.lifespan") as mock_lifespan:
+
+        @asynccontextmanager
+        async def _noop(app):  # type: ignore[no-untyped-def]  # noqa: ANN001
+            yield
+
+        mock_lifespan.side_effect = _noop
+        app = create_app()
+
+    async def _override_session() -> AsyncGenerator[AsyncMock]:
+        """
+        Yield the mock session.
+
+        Yields
+        ------
+        AsyncMock
+            The mock database session.
+        """
+        yield session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_embedding_client] = lambda: client
+    return app
+
+
+def _mock_row(
+    doc_name: str, content: str, similarity: float, chunk_id: uuid.UUID | None = None
+) -> MagicMock:
+    """
+    Create a mock DB result row.
+
+    Parameters
+    ----------
+    doc_name : str
+        Document name.
+    content : str
+        Chunk content.
+    similarity : float
+        Cosine similarity score.
+    chunk_id : uuid.UUID | None
+        Optional chunk ID. Generated if None.
+
+    Returns
+    -------
+    MagicMock
+        Mock row with DocumentChunk and similarity attributes.
+    """
+    row = MagicMock()
+    row.DocumentChunk.id = chunk_id or uuid.uuid4()
+    row.DocumentChunk.document_name = doc_name
+    row.DocumentChunk.content = content
+    row.DocumentChunk.metadata_ = {}
+    row.similarity = similarity
+    return row
+
+
+@pytest.mark.asyncio
+async def test_search_returns_results() -> None:
+    """Test that POST /search returns ranked results."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [
+        _mock_row("doc1.md", "hello world", 0.95),
+        _mock_row("doc2.md", "foo bar", 0.80),
+    ]
+    session.execute.return_value = mock_result
+
+    client = MagicMock()
+    client.encode.return_value = [[0.1] * 384]
+
+    app = _make_app(session, client)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.post("/search", json={"query": "hello", "top_k": 3})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == "hello"
+    assert data["total_results"] == 2
+    assert len(data["results"]) == 2
+    assert data["results"][0]["similarity_score"] == 0.95
+    assert data["results"][1]["similarity_score"] == 0.80
+    assert "embedding_time_ms" in data
+    assert "search_time_ms" in data
+    client.encode.assert_called_once_with(["hello"])
+
+
+@pytest.mark.asyncio
+async def test_search_empty_db() -> None:
+    """Test that POST /search on empty DB returns empty results."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    session.execute.return_value = mock_result
+
+    client = MagicMock()
+    client.encode.return_value = [[0.1] * 384]
+
+    app = _make_app(session, client)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.post("/search", json={"query": "something"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_results"] == 0
+    assert data["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query_rejected() -> None:
+    """Test that POST /search with empty query returns 422."""
+    session = AsyncMock()
+    client = MagicMock()
+
+    app = _make_app(session, client)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.post("/search", json={"query": "", "top_k": 5})
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_search_top_k_one() -> None:
+    """Test that POST /search with top_k=1 returns at most 1 result."""
+    chunk_id = uuid.uuid4()
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [
+        _mock_row("doc1.md", "best match", 0.99, chunk_id),
+    ]
+    session.execute.return_value = mock_result
+
+    client = MagicMock()
+    client.encode.return_value = [[0.1] * 384]
+
+    app = _make_app(session, client)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.post("/search", json={"query": "test", "top_k": 1})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_results"] == 1
+    assert data["results"][0]["chunk_id"] == str(chunk_id)
+    assert data["results"][0]["content"] == "best match"
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_top_k() -> None:
+    """Test that POST /search with top_k=0 returns 422."""
+    session = AsyncMock()
+    client = MagicMock()
+
+    app = _make_app(session, client)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.post("/search", json={"query": "test", "top_k": 0})
+
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Implements `POST /search` semantic search endpoint (RAG-018)
- Embeds query via `EmbeddingClient`, searches pgvector using cosine distance (`1 - <=>`)
- Filters by `similarity_threshold`, limits by `top_k`, returns results ordered by descending similarity
- Includes `embedding_time_ms` and `search_time_ms` timing in response
- Uses FastAPI `Depends` for DI of DB session and embedding client
- 18 tests pass (5 new search tests), 100% coverage on search.py

## Test plan
- [x] `uv run ruff check` — no violations
- [x] `uv run ruff format --check` — formatted
- [x] `uv run mypy rag_retriever/` — passes strict
- [x] `uv run pytest -v` — 18 tests pass, 85% coverage
- [x] `pre-commit run --files` — all hooks pass (including numpydoc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)