### PR TITLE
feat(rag-retriever): implement GET /documents/stats endpoint

### DIFF
--- a/python/rag-retriever/rag_retriever/api.py
+++ b/python/rag-retriever/rag_retriever/api.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from rag_retriever.dependencies import init_dependencies, shutdown_dependencies
+from rag_retriever.routes.documents import router as documents_router
 from rag_retriever.routes.health import router as health_router
 from rag_retriever.routes.search import router as search_router
 
@@ -47,4 +48,5 @@ def create_app() -> FastAPI:
     )
     app.include_router(health_router)
     app.include_router(search_router)
+    app.include_router(documents_router)
     return app

--- a/python/rag-retriever/rag_retriever/routes/documents.py
+++ b/python/rag-retriever/rag_retriever/routes/documents.py
@@ -1,0 +1,47 @@
+"""Document stats endpoint."""
+
+from fastapi import APIRouter, Depends
+from lib_orm.models import DocumentChunk
+from lib_schemas.schemas import StatsResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from rag_retriever.dependencies import get_db_session
+from rag_retriever.task_inputs import task_inputs
+
+router = APIRouter(prefix="/documents")
+
+
+@router.get("/stats")
+async def stats(
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+) -> StatsResponse:
+    """
+    Return document and chunk statistics.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Injected database session.
+
+    Returns
+    -------
+    StatsResponse
+        Counts of documents and chunks, plus model metadata.
+    """
+    result = await session.execute(
+        select(
+            func.count(func.distinct(DocumentChunk.document_name)),
+            func.count(),
+        )
+    )
+    row = result.one()
+    total_documents: int = row[0]
+    total_chunks: int = row[1]
+
+    return StatsResponse(
+        total_documents=total_documents,
+        total_chunks=total_chunks,
+        embedding_dimension=384,
+        model_name=task_inputs.embedding_model,
+    )

--- a/python/rag-retriever/tests/test_documents.py
+++ b/python/rag-retriever/tests/test_documents.py
@@ -1,0 +1,89 @@
+"""Tests for GET /documents/stats endpoint."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from rag_retriever.api import create_app
+from rag_retriever.dependencies import get_db_session
+
+
+def _make_app(session: AsyncMock) -> object:
+    """
+    Create a test app with overridden DB session dependency.
+
+    Parameters
+    ----------
+    session : AsyncMock
+        Mock database session.
+
+    Returns
+    -------
+    object
+        FastAPI app with dependency overrides.
+    """
+    with patch("rag_retriever.api.lifespan") as mock_lifespan:
+
+        @asynccontextmanager
+        async def _noop(app):  # type: ignore[no-untyped-def]  # noqa: ANN001
+            yield
+
+        mock_lifespan.side_effect = _noop
+        app = create_app()
+
+    async def _override_session() -> AsyncGenerator[AsyncMock]:
+        """
+        Yield the mock session.
+
+        Yields
+        ------
+        AsyncMock
+            The mock database session.
+        """
+        yield session
+
+    app.dependency_overrides[get_db_session] = _override_session  # type: ignore[union-attr]
+    return app
+
+
+@pytest.mark.asyncio
+async def test_stats_with_data() -> None:
+    """Test that GET /documents/stats returns correct counts."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.one.return_value = (3, 26)
+    session.execute.return_value = mock_result
+
+    app = _make_app(session)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.get("/documents/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_documents"] == 3
+    assert data["total_chunks"] == 26
+    assert data["embedding_dimension"] == 384
+    assert data["model_name"] == "all-MiniLM-L6-v2"
+
+
+@pytest.mark.asyncio
+async def test_stats_empty_db() -> None:
+    """Test that GET /documents/stats returns zeros on empty DB."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.one.return_value = (0, 0)
+    session.execute.return_value = mock_result
+
+    app = _make_app(session)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.get("/documents/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_documents"] == 0
+    assert data["total_chunks"] == 0


### PR DESCRIPTION
## Summary
- Implements `GET /documents/stats` endpoint (RAG-019)
- Queries `COUNT(DISTINCT document_name)` and `COUNT(*)` from `document_chunks`
- Returns `StatsResponse` with `total_documents`, `total_chunks`, `embedding_dimension` (384), `model_name`
- 20 tests pass (2 new stats tests), 100% coverage on documents.py

## Test plan
- [x] `uv run ruff check` — no violations
- [x] `uv run ruff format --check` — formatted
- [x] `uv run mypy rag_retriever/` — passes strict
- [x] `uv run pytest -v` — 20 tests pass, 87% coverage
- [x] `pre-commit run --files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)