### PR TITLE
feat(rag-retriever): wire up App.run() with uvicorn and lifespan logging

### DIFF
--- a/python/rag-retriever/rag_retriever/api.py
+++ b/python/rag-retriever/rag_retriever/api.py
@@ -26,9 +26,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     None
         Yields control to the application during its lifetime.
     """
+    print("Starting up: initializing DB engine and embedding model...")
     await init_dependencies()
+    print("Startup complete: all dependencies ready")
     yield
+    print("Shutting down: releasing resources...")
     await shutdown_dependencies()
+    print("Shutdown complete")
 
 
 def create_app() -> FastAPI:


### PR DESCRIPTION
## Summary
- Completes `App.run()` wiring with uvicorn and lifespan (RAG-020)
- Adds startup/shutdown logging to the lifespan so users see initialization progress
- `App.run()` prints config then starts uvicorn with the factory (done in RAG-017)
- Lifespan startup preloads embedding model + DB engine, shutdown disposes resources
- All 20 tests pass

## Test plan
- [x] `uv run ruff check` — no violations
- [x] `uv run ruff format --check` — formatted
- [x] `uv run mypy rag_retriever/` — passes strict
- [x] `uv run pytest -v` — 20 tests pass, 84% coverage
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)