### PR TITLE
feat(rag-pipeline): KFP component definitions for loader and embedder

### DIFF
--- a/python/rag-pipeline/rag_pipeline/components/embedder.py
+++ b/python/rag-pipeline/rag_pipeline/components/embedder.py
@@ -1,0 +1,55 @@
+"""KFP component definition for rag-embedder."""
+
+from kfp import dsl
+
+EMBEDDER_IMAGE = "rag-embedder:latest"
+
+
+@dsl.container_component  # type: ignore[untyped-decorator]
+def embedder_component(
+    chunks_artifact: dsl.Input[dsl.Artifact],  # noqa: B008
+    db_url: str,
+    embedding_model: str,
+    batch_size: int,
+    embeddings_artifact: dsl.Output[dsl.Artifact],  # noqa: B008
+) -> dsl.ContainerSpec:
+    """
+    Embed chunks and write to pgvector.
+
+    Reads chunk JSON from the input artifact, generates embeddings,
+    saves them to the output artifact, and writes to the database.
+
+    Parameters
+    ----------
+    chunks_artifact : dsl.Input[dsl.Artifact]
+        Input artifact containing chunk JSON files.
+    db_url : str
+        Database connection URL.
+    embedding_model : str
+        Name of the sentence-transformers model.
+    batch_size : int
+        Number of chunks to embed per batch.
+    embeddings_artifact : dsl.Output[dsl.Artifact]
+        Output artifact for embedding JSON files.
+
+    Returns
+    -------
+    dsl.ContainerSpec
+        Container specification for the embedder component.
+    """
+    return dsl.ContainerSpec(
+        image=EMBEDDER_IMAGE,
+        command=["python", "-m", "rag_embedder.main"],
+        args=[
+            "--input_dir",
+            chunks_artifact.path,
+            "--output_dir",
+            embeddings_artifact.path,
+            "--db_url",
+            db_url,
+            "--embedding_model",
+            embedding_model,
+            "--batch_size",
+            str(batch_size),
+        ],
+    )

--- a/python/rag-pipeline/rag_pipeline/components/loader.py
+++ b/python/rag-pipeline/rag_pipeline/components/loader.py
@@ -1,0 +1,50 @@
+"""KFP component definition for rag-loader."""
+
+from kfp import dsl
+
+LOADER_IMAGE = "rag-loader:latest"
+
+
+@dsl.container_component  # type: ignore[untyped-decorator]
+def loader_component(
+    input_dir: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    chunks_artifact: dsl.Output[dsl.Artifact],  # noqa: B008
+) -> dsl.ContainerSpec:
+    """
+    Load and chunk documents from input directory.
+
+    Reads documents, splits them into chunks, and writes chunk JSON
+    to the output artifact path.
+
+    Parameters
+    ----------
+    input_dir : str
+        Directory containing input documents.
+    chunk_size : int
+        Maximum number of characters per chunk.
+    chunk_overlap : int
+        Number of overlapping characters between consecutive chunks.
+    chunks_artifact : dsl.Output[dsl.Artifact]
+        Output artifact for chunk JSON files.
+
+    Returns
+    -------
+    dsl.ContainerSpec
+        Container specification for the loader component.
+    """
+    return dsl.ContainerSpec(
+        image=LOADER_IMAGE,
+        command=["python", "-m", "rag_loader.main"],
+        args=[
+            "--input_dir",
+            input_dir,
+            "--output_dir",
+            chunks_artifact.path,
+            "--chunk_size",
+            str(chunk_size),
+            "--chunk_overlap",
+            str(chunk_overlap),
+        ],
+    )

--- a/python/rag-pipeline/tests/test_components.py
+++ b/python/rag-pipeline/tests/test_components.py
@@ -1,0 +1,34 @@
+"""Tests for KFP component definitions."""
+
+from rag_pipeline.components.embedder import EMBEDDER_IMAGE, embedder_component
+from rag_pipeline.components.loader import LOADER_IMAGE, loader_component
+
+
+def test_loader_component_importable() -> None:
+    """Test that loader_component can be imported without errors."""
+    assert callable(loader_component)
+
+
+def test_loader_image() -> None:
+    """Test that loader component uses correct image."""
+    assert LOADER_IMAGE == "rag-loader:latest"
+
+
+def test_embedder_component_importable() -> None:
+    """Test that embedder_component can be imported without errors."""
+    assert callable(embedder_component)
+
+
+def test_embedder_image() -> None:
+    """Test that embedder component uses correct image."""
+    assert EMBEDDER_IMAGE == "rag-embedder:latest"
+
+
+def test_loader_component_has_pipeline_channel() -> None:
+    """Test that loader_component is a valid KFP component."""
+    assert hasattr(loader_component, "pipeline_func")
+
+
+def test_embedder_component_has_pipeline_channel() -> None:
+    """Test that embedder_component is a valid KFP component."""
+    assert hasattr(embedder_component, "pipeline_func")


### PR DESCRIPTION
## Summary
- Implements KFP `@dsl.container_component` definitions for rag-loader and rag-embedder (RAG-022)
- `loader_component`: takes `input_dir`, `chunk_size`, `chunk_overlap`, outputs `chunks_artifact`
- `embedder_component`: takes `chunks_artifact` (from loader), `db_url`, `embedding_model`, `batch_size`, outputs `embeddings_artifact`
- Components reference `rag-loader:latest` and `rag-embedder:latest` Docker images
- Component signatures match respective package TaskInputs
- 8 tests pass (6 new component tests)

## Test plan
- [x] `uv run ruff check` — no violations
- [x] `uv run ruff format --check` — formatted
- [x] `uv run mypy rag_pipeline/` — passes strict
- [x] `uv run pytest -v` — 8 tests pass, 82% coverage
- [x] `pre-commit run --files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)