### PR TITLE
feat: add course materials and starter repo generator

### DIFF
--- a/course/fiche-de-cours.md
+++ b/course/fiche-de-cours.md
@@ -1,0 +1,130 @@
+# Fiche de cours
+
+## 1. Identification
+
+| | |
+|---|---|
+| **Intitulé** | Système RAG et MLOps avec Kubeflow Pipelines |
+| **Volume horaire** | 21 heures (3 séances de 7 heures) |
+| **Modalité** | Travaux pratiques (100 % hands-on) |
+| **Langue** | Français (outils et code en anglais) |
+| **Niveau** | M1/M2 — Data Engineering |
+| **Enseignant(s)** | _À compléter_ |
+
+## 2. Prérequis
+
+| Domaine | Niveau attendu |
+|---------|---------------|
+| Python | Intermédiaire : classes, async/await, décorateurs, type hints |
+| SQL | SELECT, INSERT, JOIN, index, création de tables |
+| Git / GitHub | clone, branch, commit, push, pull request |
+| Ligne de commande | Navigation, variables d'environnement, scripts |
+| Docker | Images, conteneurs, `docker compose up/down` |
+| Kubernetes | _Souhaitable_ : notions de pods, services, kubectl |
+
+## 3. Objectifs pédagogiques
+
+À l'issue de ce cours, l'étudiant sera capable de :
+
+1. **Concevoir un pipeline d'ingestion de données textuelles** — lecture de documents, découpage en chunks avec recouvrement, sérialisation JSON.
+2. **Stocker et rechercher des vecteurs avec pgvector** — utiliser PostgreSQL comme base de données vectorielle, effectuer des recherches par similarité cosinus.
+3. **Développer une API REST avec FastAPI** — application factory, injection de dépendances, endpoints asynchrones pour la recherche sémantique.
+4. **Orchestrer un pipeline ML avec Kubeflow Pipelines sur Kubernetes** — définir des composants KFP, compiler un pipeline, le soumettre à un cluster Kind local.
+5. **Appliquer les bonnes pratiques MLOps** — conteneurisation Docker, tests automatisés, linting (ruff), typage strict (mypy), pre-commit hooks.
+6. **Structurer un projet Python multi-packages** — gestion des dépendances avec uv, justfile, pyproject.toml, bibliothèques partagées.
+
+## 4. Compétences visées
+
+| Code | Compétence | Objectif(s) |
+|------|-----------|-------------|
+| C1 | Pipeline de données et traitement de texte | 1 |
+| C2 | Bases de données vectorielles et recherche sémantique | 2 |
+| C3 | Développement d'API REST (FastAPI, Python asynchrone) | 3 |
+| C4 | Orchestration ML (Kubeflow Pipelines, Kubernetes) | 4 |
+| C5 | Pratiques MLOps (conteneurisation, qualité de code, tests) | 5, 6 |
+
+## 5. Contenu des séances
+
+### Séance 1 (7h) — Fondations : Infrastructure, bibliothèques partagées et loader
+
+- Mise en place de l'environnement : Docker, pre-commit, `docker compose`, justfile
+- Découverte des bibliothèques partagées : schémas Pydantic (`lib-schemas`), client d'embedding (`lib-embedding`), ORM asynchrone (`lib-orm`)
+- Implémentation du pipeline de chargement (`rag-loader`) : lecture de fichiers, découpage en chunks (algorithme récursif ~50 lignes), écriture JSON
+
+**Livrable** : `just load` produit un fichier JSON de chunks. Tous les tests des bibliothèques passent.
+
+### Séance 2 (7h) — Embedding et API : Embedder et Retriever
+
+- Vectorisation et stockage dans pgvector : batch upsert asynchrone avec gestion des conflits
+- API FastAPI (`rag-retriever`) : factory pattern, injection de dépendances, `POST /search`, `GET /documents/stats`
+- Pipeline locale complète : chargement → embedding → recherche sémantique
+
+**Livrable** : le système RAG fonctionne en local. Une requête `just query "qu'est-ce que le MLOps ?"` retourne des résultats pertinents classés par score.
+
+### Séance 3 (7h) — Orchestration : Kubeflow Pipelines sur Kubernetes
+
+- Cluster Kind et déploiement Kubeflow Pipelines (standalone)
+- Composants KFP (`@dsl.container_component`), définition du pipeline, compilation YAML
+- Conteneurisation (Dockerfiles multi-stage), chargement d'images dans Kind
+- Test d'intégration de bout en bout
+
+**Livrable** : le pipeline KFP s'exécute sur le cluster Kind, le test e2e passe, l'interface KFP affiche le run.
+
+## 6. Méthodes pédagogiques
+
+| Méthode | Description |
+|---------|------------|
+| **TP guidé par issues GitHub** | Chaque tâche est décrite dans une issue GitHub avec objectif, fichiers à modifier, commande de vérification et indices progressifs. |
+| **Approche TDD** | Les tests unitaires sont fournis. L'étudiant implémente le code jusqu'à ce que les tests passent. |
+| **Démonstrations live** | L'enseignant démontre les concepts complexes (architecture, pgvector, FastAPI, KFP) avant chaque bloc pratique. |
+| **Squelettes typés** | Les signatures de fonctions avec type hints sont fournies. L'étudiant implémente les corps de fonctions. |
+| **Repository template GitHub** | Les étudiants partent d'un repo template contenant le scaffolding, les bibliothèques partagées, les tests et la configuration. |
+
+## 7. Matériel requis
+
+### Logiciels à installer avant la première séance
+
+| Outil | Version | Usage |
+|-------|---------|-------|
+| Docker Desktop | Dernière version | Conteneurs, PostgreSQL |
+| Python | >= 3.13 | Langage principal |
+| uv | Dernière version | Gestionnaire de paquets Python |
+| kind | Dernière version | Cluster Kubernetes local |
+| kubectl | Dernière version | CLI Kubernetes |
+| Git | Dernière version | Versionnement |
+| VS Code | Dernière version | Éditeur recommandé (extensions : Python, Ruff) |
+
+### Matériel
+
+- Ordinateur portable (8 Go RAM minimum, 16 Go recommandé)
+- Connexion internet (téléchargement des images Docker et du modèle d'embedding lors de la 1re séance)
+- Compte GitHub
+
+## 8. Évaluation
+
+### Modalité : évaluation continue
+
+| Critère | Pondération | Détail |
+|---------|-------------|--------|
+| Progression sur les issues | 40 % | Épiques 1-5 = minimum attendu |
+| Qualité du code | 30 % | Tests passants (`just test-all`), lint propre (`just check-all`), pre-commit |
+| Pipeline Kubeflow fonctionnel | 20 % | Épique 6 : pipeline soumis et exécuté sur Kind |
+| Test d'intégration | 10 % | Épique 7 : test e2e passe (`just e2e`) |
+
+### Rendu
+
+- Repository GitHub avec code source, tests passants, README
+- Démonstration live du pipeline complet (5 minutes par étudiant/binôme)
+
+## 9. Ressources
+
+| Ressource | Lien |
+|-----------|------|
+| Repository template | _À compléter (rag-kubeflow-starter)_ |
+| FastAPI | https://fastapi.tiangolo.com |
+| pgvector | https://github.com/pgvector/pgvector |
+| Kubeflow Pipelines | https://www.kubeflow.org/docs/components/pipelines/ |
+| sentence-transformers | https://www.sbert.net |
+| uv | https://docs.astral.sh/uv/ |
+| kind | https://kind.sigs.k8s.io |
+| SQLAlchemy async | https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html |

--- a/course/quickstart.md
+++ b/course/quickstart.md
@@ -1,0 +1,140 @@
+# Quickstart — De l'infrastructure au query
+
+> Guide pas-a-pas pour lancer le RAG de bout en bout.
+> Pre-requis : avoir suivi le [guide d'installation](setup-guide.md).
+
+## 1. Demarrer l'infrastructure
+
+```bash
+# Demarre Docker Desktop, PostgreSQL, Kind cluster, KFP
+just infra-up
+```
+
+Cela fait, dans l'ordre :
+
+1. Docker Desktop (si pas deja lance)
+2. PostgreSQL + pgvector via `docker compose up -d`
+3. Creation du cluster Kind `rag-kubeflow`
+4. Deploiement de Kubeflow Pipelines (KFP standalone)
+5. Chargement des images Docker dans Kind
+
+Verifier que tout est en place :
+
+```bash
+just infra-status
+```
+
+Tous les pods doivent etre en `Running`.
+
+## 2. Preparer les documents
+
+Placer vos fichiers `.md` ou `.txt` dans le dossier `data/documents/` a la racine du projet :
+
+```
+data/
+  documents/
+    mon-document.md
+    autre-fichier.txt
+```
+
+## 3. Construire les images Docker
+
+```bash
+just build-images
+```
+
+Cela construit les images `rag-loader`, `rag-embedder` et `rag-retriever`.
+
+## 4. Charger les images dans Kind
+
+```bash
+just kfp-load-images
+```
+
+Les images sont maintenant disponibles dans le cluster Kind.
+
+## 5. Lancer le pipeline sur KFP
+
+### Option A : via KFP (Kubeflow Pipelines)
+
+Ouvrir **deux terminaux** :
+
+```bash
+# Terminal 1 — port-forward du KFP UI
+just kfp-ui
+```
+
+```bash
+# Terminal 2 — soumettre le pipeline
+just kfp-submit
+```
+
+Suivre l'execution dans le navigateur : http://localhost:8080
+
+### Option B : en local (sans Kubernetes)
+
+```bash
+just pipeline
+```
+
+Cela execute le loader puis l'embedder directement sur votre machine.
+
+## 6. Verifier l'execution (KFP)
+
+```bash
+# Voir les pods du pipeline
+kubectl get pods -n kubeflow --context kind-rag-kubeflow
+
+# Voir le statut de l'infra
+just kfp-status
+```
+
+Les pods `rag-ingestion-*` apparaissent pendant l'execution et passent en `Completed` une fois termines.
+
+## 7. Demarrer le serveur de recherche
+
+```bash
+just serve
+```
+
+Le serveur FastAPI demarre sur http://localhost:8000.
+
+- Documentation API : http://localhost:8000/docs
+- Health check : http://localhost:8000/health
+
+## 8. Lancer une requete
+
+```bash
+just query "qu'est-ce que le machine learning?"
+```
+
+Ou directement avec curl :
+
+```bash
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "qu est-ce que le machine learning", "top_k": 5}'
+```
+
+## 9. Arreter l'infrastructure
+
+```bash
+just infra-down
+```
+
+Cela supprime le cluster Kind et arrete PostgreSQL.
+
+## Resume des commandes
+
+| Etape | Commande |
+|-------|----------|
+| Demarrer l'infra | `just infra-up` |
+| Verifier l'infra | `just infra-status` |
+| Construire les images | `just build-images` |
+| Charger les images dans Kind | `just kfp-load-images` |
+| Ouvrir le KFP UI | `just kfp-ui` |
+| Soumettre le pipeline | `just kfp-submit` |
+| Pipeline local (sans K8s) | `just pipeline` |
+| Demarrer le retriever | `just serve` |
+| Requete | `just query "ma question"` |
+| Arreter l'infra | `just infra-down` |

--- a/course/session-1.md
+++ b/course/session-1.md
@@ -1,0 +1,375 @@
+# Session 1 (7h) — Fondations
+
+> Infrastructure, bibliothèques partagées et document loader
+
+## Planning
+
+| Horaire | Activité | Type |
+|---------|----------|------|
+| 0:00-0:45 | Introduction, architecture, vérification de l'environnement | Cours |
+| 0:45-1:15 | Epic 1 : pre-commit, docker-compose, justfile | Guidé |
+| 1:15-1:30 | Pause | |
+| 1:30-2:00 | Démo : patron package-1, Pydantic BaseSettings | Cours |
+| 2:00-3:30 | Epic 2 : découverte des bibliothèques partagées (fournies) | Lecture + exploration |
+| 3:30-3:45 | Pause | |
+| 3:45-5:45 | Epic 3 : implémentation de rag-loader | Hands-on |
+| 5:45-6:30 | Exécution de `just load`, vérification du JSON, tests | Hands-on |
+| 6:30-7:00 | Récapitulatif + Q&A | Cours |
+
+**Livrable** : `just load` produit un fichier `data/chunks/chunks.json`. Tous les tests passent.
+
+---
+
+## Epic 1 — Infrastructure (guidé, ~30 min)
+
+Ces fichiers sont **fournis dans le template**. L'enseignant les parcourt avec les étudiants.
+
+### Tâche 1.1 : Vérifier l'environnement
+
+```bash
+docker --version          # Docker Desktop installé
+python --version          # >= 3.13
+uv --version              # uv installé
+kind --version            # kind installé
+kubectl version --client  # kubectl installé
+git --version             # git installé
+```
+
+### Tâche 1.2 : Démarrer PostgreSQL
+
+```bash
+docker compose up -d
+docker compose ps          # postgres healthy
+```
+
+Vérifier la connexion :
+
+```bash
+docker exec -it rag-postgres psql -U rag -d rag -c "\dt"
+```
+
+La table `document_chunks` doit apparaître (créée par `infra/init.sql`).
+
+### Tâche 1.3 : Installer pre-commit
+
+```bash
+pip install pre-commit     # ou uv tool install pre-commit
+pre-commit install
+pre-commit run --all-files # tout doit passer
+```
+
+### Tâche 1.4 : Explorer le justfile racine
+
+```bash
+just --list                # voir toutes les recettes disponibles
+```
+
+Comprendre les recettes `infra-up`, `infra-down`, `load`, `embed`, `serve`, `query`.
+
+---
+
+## Epic 2 — Bibliothèques partagées (fournies, ~1h30)
+
+Les 3 bibliothèques sont **fournies complètes**. L'objectif est de les comprendre car elles seront utilisées dans les packages suivants.
+
+### Tâche 2.1 : Explorer lib-schemas
+
+**Fichier** : `python/lib-schemas/lib_schemas/schemas.py`
+
+Modèles Pydantic partagés entre les packages :
+
+| Classe | Usage |
+|--------|-------|
+| `ChunkInput` | Chunk de texte (document_name, chunk_index, content, metadata) |
+| `ChunkWithEmbedding` | ChunkInput + vecteur embedding (list[float]) |
+| `SearchRequest` | Requête API (query, top_k, similarity_threshold) |
+| `SearchResult` | Résultat de recherche (chunk_id, document_name, content, similarity_score) |
+| `SearchResponse` | Réponse API (results, total_results, timings) |
+| `StatsResponse` | Statistiques documents (total_documents, total_chunks, embedding_dimension, model_name) |
+
+**Vérification** :
+
+```bash
+cd python/lib-schemas && just test
+```
+
+### Tâche 2.2 : Explorer lib-embedding
+
+**Fichier** : `python/lib-embedding/lib_embedding/embedding.py`
+
+- `EmbeddingClient(model_name)` — charge le modèle sentence-transformers
+- `encode(texts: list[str]) -> list[list[float]]` — encode une liste de textes en vecteurs 384-dim
+- `dimension` — propriété retournant la dimension du modèle
+
+**Vérification** :
+
+```bash
+cd python/lib-embedding && just test
+```
+
+### Tâche 2.3 : Explorer lib-orm
+
+**Fichiers** :
+- `python/lib-orm/lib_orm/db.py` — `get_async_engine()`, `get_async_session()`
+- `python/lib-orm/lib_orm/models.py` — ORM `DocumentChunk` (SQLAlchemy + pgvector)
+
+La table `document_chunks` correspond au schéma dans `infra/init.sql` :
+- `id` (UUID), `document_name`, `chunk_index`, `content`, `metadata` (JSONB), `embedding` (vector(384))
+
+**Vérification** :
+
+```bash
+cd python/lib-orm && just test
+```
+
+---
+
+## Epic 3 — Document Loader (hands-on, ~2h)
+
+C'est le premier package que les étudiants **implémentent eux-mêmes**.
+
+### Tâche 3.1 : Comprendre la structure du package
+
+```
+python/rag-loader/
+├── rag_loader/
+│   ├── __init__.py       # fourni
+│   ├── main.py           # fourni (projen, ne pas modifier)
+│   ├── task_inputs.py    # fourni
+│   ├── app.py            # À IMPLÉMENTER
+│   ├── reader.py         # À IMPLÉMENTER
+│   └── chunker.py        # À IMPLÉMENTER
+├── tests/                # fournis
+├── pyproject.toml        # fourni
+├── justfile              # fourni
+└── uv.lock               # fourni
+```
+
+Installer les dépendances :
+
+```bash
+cd python/rag-loader && just install-dev
+```
+
+Exécuter les tests pour voir ce qui échoue :
+
+```bash
+just test   # tout doit être rouge sauf test_init et test_task_inputs
+```
+
+### Tâche 3.2 : Implémenter le lecteur de documents
+
+**Fichier** : `python/rag-loader/rag_loader/reader.py`
+
+**Fonction à implémenter** :
+
+```python
+SUPPORTED_EXTENSIONS = {".txt", ".md"}
+
+def read_documents(input_dir: str) -> list[dict[str, object]]:
+```
+
+**Comportement attendu** :
+1. Vérifier que `input_dir` existe et est un dossier (sinon `FileNotFoundError` / `NotADirectoryError`)
+2. Lister les fichiers `.md` et `.txt` uniquement (non récursif)
+3. Trier les fichiers par nom avant traitement
+4. Lire chaque fichier en UTF-8 (utiliser `encoding="utf-8-sig"` pour gérer le BOM)
+5. Retourner une liste de dicts avec les clés : `document_name`, `content`, `metadata`
+6. `metadata` contient `file_size` (int) et `extension` (str)
+
+**Vérification** :
+
+```bash
+just test -- -k test_reader   # 8 tests doivent passer
+```
+
+<details>
+<summary>Indice 1 : structure de base</summary>
+
+```python
+from pathlib import Path
+
+def read_documents(input_dir: str) -> list[dict[str, object]]:
+    path = Path(input_dir)
+    if not path.exists():
+        raise FileNotFoundError(...)
+    if not path.is_dir():
+        raise NotADirectoryError(...)
+
+    documents = []
+    for file_path in sorted(path.iterdir()):
+        if file_path.suffix in SUPPORTED_EXTENSIONS:
+            # lire le fichier et construire le dict
+            ...
+    return documents
+```
+
+</details>
+
+<details>
+<summary>Indice 2 : construction du dict retourné</summary>
+
+```python
+content = file_path.read_text(encoding="utf-8-sig")
+documents.append({
+    "document_name": file_path.name,
+    "content": content,
+    "metadata": {
+        "file_size": file_path.stat().st_size,
+        "extension": file_path.suffix,
+    },
+})
+```
+
+</details>
+
+### Tâche 3.3 : Implémenter le chunker
+
+**Fichier** : `python/rag-loader/rag_loader/chunker.py`
+
+C'est l'algorithme le plus intéressant de la session : un **recursive character splitter** (~50 lignes).
+
+**Fonctions à implémenter** :
+
+```python
+SEPARATORS = ["\n\n", "\n", ". ", " ", ""]
+
+def chunk_text(text: str, chunk_size: int = 512, chunk_overlap: int = 64) -> list[str]:
+    ...
+
+def _split_recursive(text: str, chunk_size: int, sep_idx: int) -> list[str]:
+    ...
+
+def _merge_with_overlap(segments: list[str], chunk_size: int, chunk_overlap: int) -> list[str]:
+    ...
+```
+
+**Algorithme de `chunk_text`** :
+1. Lever `ValueError` si `chunk_overlap >= chunk_size`
+2. Retourner `[]` si le texte est vide ou ne contient que des espaces
+3. Appeler `_split_recursive(text, chunk_size, 0)` pour obtenir des segments
+4. Appeler `_merge_with_overlap(segments, chunk_size, chunk_overlap)` pour fusionner avec recouvrement
+
+**Algorithme de `_split_recursive`** :
+1. Si `len(text) <= chunk_size` : retourner `[text]`
+2. Si `sep_idx >= len(SEPARATORS)` : retourner `[text]` (dernier recours)
+3. Séparer le texte avec `SEPARATORS[sep_idx]`
+4. Pour le séparateur `""` : découper caractère par caractère (`text[i:i+chunk_size]`)
+5. Si le split ne produit qu'un seul morceau : essayer le séparateur suivant
+6. Pour `". "` : rattacher le `.` à la fin de chaque segment
+7. Filtrer les segments vides, et récurser sur les segments trop longs
+
+**Algorithme de `_merge_with_overlap`** :
+1. Fusionner les segments tant que `len(merged) + 1 + len(next) <= chunk_size`
+2. Quand la limite est atteinte : sauvegarder le chunk courant, calculer le recouvrement depuis la fin
+3. Le recouvrement = derniers `chunk_overlap` caractères du chunk qui vient d'être sauvegardé
+
+**Vérification** :
+
+```bash
+just test -- -k test_chunker   # 13 tests doivent passer
+```
+
+<details>
+<summary>Indice 1 : _split_recursive cas de base</summary>
+
+```python
+def _split_recursive(text: str, chunk_size: int, sep_idx: int) -> list[str]:
+    if len(text) <= chunk_size:
+        return [text]
+    if sep_idx >= len(SEPARATORS):
+        return [text]
+
+    sep = SEPARATORS[sep_idx]
+    if sep == "":
+        return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+    ...
+```
+
+</details>
+
+<details>
+<summary>Indice 2 : _merge_with_overlap boucle principale</summary>
+
+```python
+def _merge_with_overlap(segments, chunk_size, chunk_overlap):
+    if not segments:
+        return []
+    chunks = []
+    current = segments[0]
+    for seg in segments[1:]:
+        candidate = current + " " + seg
+        if len(candidate) <= chunk_size:
+            current = candidate
+        else:
+            chunks.append(current)
+            overlap_text = current[-chunk_overlap:] if chunk_overlap > 0 else ""
+            current = (overlap_text + " " + seg).strip() if overlap_text else seg
+    chunks.append(current)
+    return chunks
+```
+
+</details>
+
+### Tâche 3.4 : Implémenter App.run()
+
+**Fichier** : `python/rag-loader/rag_loader/app.py`
+
+**Méthode à implémenter** : `App.run(self) -> None`
+
+**Comportement attendu** :
+1. Afficher la configuration de `task_inputs` (input_dir, output_dir, chunk_size, chunk_overlap)
+2. Appeler `read_documents(task_inputs.input_dir)`
+3. Pour chaque document : appeler `chunk_text()` et créer des objets `ChunkInput` (de `lib_schemas`)
+4. Créer le dossier de sortie (`output_dir`) s'il n'existe pas
+5. Écrire la liste de chunks en JSON dans `output_dir/chunks.json`
+6. Afficher des messages de progression ("Read N documents", "Generated N chunks")
+
+**Imports nécessaires** :
+
+```python
+import json
+from pathlib import Path
+from lib_schemas.schemas import ChunkInput
+from rag_loader.chunker import chunk_text
+from rag_loader.reader import read_documents
+from rag_loader.task_inputs import task_inputs
+```
+
+**Vérification** :
+
+```bash
+just test -- -k test_app     # 2 tests doivent passer
+just test                     # TOUS les tests doivent passer
+just check-all                # ruff + mypy clean
+```
+
+### Tâche 3.5 : Exécuter le loader
+
+```bash
+just run   # depuis python/rag-loader/
+# ou depuis la racine :
+just load
+```
+
+Vérifier le fichier `data/chunks/chunks.json` :
+
+```bash
+python -c "import json; chunks = json.load(open('data/chunks/chunks.json')); print(f'{len(chunks)} chunks')"
+```
+
+---
+
+## Récapitulatif Session 1
+
+À la fin de cette session, vous avez :
+
+- [ ] PostgreSQL + pgvector fonctionnel (`docker compose ps`)
+- [ ] Pre-commit installé et fonctionnel
+- [ ] Compris les 3 bibliothèques partagées (lib-schemas, lib-embedding, lib-orm)
+- [ ] Implémenté `reader.py` — lecture de fichiers .md/.txt
+- [ ] Implémenté `chunker.py` — recursive character splitter
+- [ ] Implémenté `app.py` — orchestration du loader
+- [ ] `just load` produit `data/chunks/chunks.json`
+- [ ] `just test` passe dans `python/rag-loader/`
+- [ ] `just check-all` passe dans `python/rag-loader/`

--- a/course/session-2.md
+++ b/course/session-2.md
@@ -1,0 +1,489 @@
+# Session 2 (7h) — Embedding et API
+
+> Embedder et Retriever : du texte aux vecteurs, des vecteurs à l'API
+
+## Planning
+
+| Horaire | Activité | Type |
+|---------|----------|------|
+| 0:00-0:30 | Récapitulatif Session 1, crash course pgvector | Cours |
+| 0:30-2:15 | Epic 4 : implémentation de rag-embedder | Hands-on |
+| 2:15-2:30 | Pause | |
+| 2:30-3:00 | Démo : FastAPI patterns, injection de dépendances | Cours |
+| 3:00-5:00 | Epic 5 : implémentation de rag-retriever | Hands-on |
+| 5:00-5:15 | Pause | |
+| 5:15-6:00 | Wire uvicorn, `just serve` + `just query` | Hands-on |
+| 6:00-6:30 | Pipeline locale complète : `just pipeline && just serve` | Démo |
+| 6:30-7:00 | `just test-all` + `just check-all`, correction | Hands-on |
+
+**Livrable** : le système RAG fonctionne en local. `just query "qu'est-ce que le MLOps ?"` retourne des résultats classés par similarité.
+
+---
+
+## Crash course pgvector (cours, ~15 min)
+
+Concepts clés à comprendre avant de coder :
+
+- **Embedding** : représentation d'un texte sous forme de vecteur de 384 nombres flottants
+- **pgvector** : extension PostgreSQL qui ajoute le type `vector(384)` et l'opérateur `<=>` (distance cosinus)
+- **Similarité cosinus** : `1 - distance`. Plus le score est proche de 1, plus les textes sont similaires
+- **IVFFlat** : index approximatif pour accélérer les recherches (pas exact, mais rapide)
+- **Upsert** : `INSERT ... ON CONFLICT DO UPDATE` — évite les doublons
+
+Schéma de la table (voir `infra/init.sql`) :
+
+```sql
+CREATE TABLE document_chunks (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_name VARCHAR(512) NOT NULL,
+    chunk_index   INTEGER NOT NULL,
+    content       TEXT NOT NULL,
+    metadata      JSONB NOT NULL DEFAULT '{}',
+    embedding     vector(384) NOT NULL,
+    created_at    TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    CONSTRAINT uq_document_chunk UNIQUE (document_name, chunk_index)
+);
+```
+
+---
+
+## Epic 4 — Embedder (hands-on, ~1h45)
+
+### Tâche 4.1 : Comprendre la structure du package
+
+```
+python/rag-embedder/
+├── rag_embedder/
+│   ├── __init__.py       # fourni
+│   ├── main.py           # fourni (projen)
+│   ├── task_inputs.py    # fourni
+│   ├── app.py            # À IMPLÉMENTER
+│   └── writer.py         # À IMPLÉMENTER
+├── tests/                # fournis
+├── pyproject.toml        # fourni
+├── justfile              # fourni
+└── uv.lock               # fourni
+```
+
+```bash
+cd python/rag-embedder && just install-dev
+just test   # voir ce qui échoue
+```
+
+**TaskInputs fournis** : `input_dir` (data/chunks), `output_dir` (data/embeddings), `db_url`, `embedding_model` (all-MiniLM-L6-v2), `batch_size` (32).
+
+### Tâche 4.2 : Implémenter le writer (batch upsert)
+
+**Fichier** : `python/rag-embedder/rag_embedder/writer.py`
+
+**Fonction à implémenter** :
+
+```python
+async def write_chunks(session: AsyncSession, chunks: list[ChunkWithEmbedding]) -> int:
+```
+
+**Comportement attendu** :
+1. Retourner `0` si la liste est vide
+2. Pour chaque chunk, chercher un `DocumentChunk` existant par `(document_name, chunk_index)`
+3. Si trouvé : mettre à jour `content`, `metadata_` et `embedding`
+4. Si non trouvé : créer un nouveau `DocumentChunk` et l'ajouter à la session
+5. Appeler `session.flush()` à la fin
+6. Retourner le nombre total de lignes affectées
+
+**Imports nécessaires** :
+
+```python
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from lib_orm.models import DocumentChunk
+from lib_schemas.schemas import ChunkWithEmbedding
+```
+
+**Vérification** :
+
+```bash
+just test -- -k test_writer   # 5 tests doivent passer
+```
+
+<details>
+<summary>Indice 1 : recherche d'un chunk existant</summary>
+
+```python
+stmt = select(DocumentChunk).where(
+    DocumentChunk.document_name == chunk.document_name,
+    DocumentChunk.chunk_index == chunk.chunk_index,
+)
+result = await session.execute(stmt)
+existing = result.scalar_one_or_none()
+```
+
+</details>
+
+<details>
+<summary>Indice 2 : création d'un nouveau DocumentChunk</summary>
+
+```python
+row = DocumentChunk(
+    document_name=chunk.document_name,
+    chunk_index=chunk.chunk_index,
+    content=chunk.content,
+    metadata_=chunk.metadata,
+    embedding=chunk.embedding,
+)
+session.add(row)
+```
+
+</details>
+
+### Tâche 4.3 : Implémenter App.run()
+
+**Fichier** : `python/rag-embedder/rag_embedder/app.py`
+
+**Méthode à implémenter** : `App.run(self) -> None`
+
+**Comportement attendu** :
+1. Afficher la configuration de `task_inputs`
+2. Charger les chunks depuis les fichiers JSON dans `input_dir` (`Path.glob("*.json")`)
+3. Valider les chunks comme liste de `ChunkInput`
+4. Créer un `EmbeddingClient(task_inputs.embedding_model)` et encoder les textes
+5. Construire des objets `ChunkWithEmbedding` avec les embeddings
+6. Sauvegarder en JSON dans `output_dir/embeddings.json`
+7. Écrire dans la base de données via `_write_to_db()` (méthode statique async, appelée via `asyncio.run()`)
+
+**Méthode statique `_write_to_db`** :
+1. Obtenir une session async via `get_async_session(task_inputs.db_url)`
+2. Appeler `write_chunks(session, results)`
+3. Gérer les erreurs de connexion gracieusement (print, pas crash)
+
+**Imports nécessaires** :
+
+```python
+import asyncio
+import json
+from pathlib import Path
+from lib_embedding.embedding import EmbeddingClient
+from lib_orm.db import get_async_session
+from lib_schemas.schemas import ChunkInput, ChunkWithEmbedding
+from rag_embedder.task_inputs import task_inputs
+from rag_embedder.writer import write_chunks
+```
+
+**Vérification** :
+
+```bash
+just test -- -k test_app   # 3 tests doivent passer
+just test                   # TOUS les tests
+just check-all              # ruff + mypy clean
+```
+
+<details>
+<summary>Indice : chargement des chunks JSON</summary>
+
+```python
+all_chunks: list[ChunkInput] = []
+for json_file in Path(task_inputs.input_dir).glob("*.json"):
+    data = json.loads(json_file.read_text())
+    all_chunks.extend([ChunkInput(**item) for item in data])
+```
+
+</details>
+
+### Tâche 4.4 : Exécuter l'embedder
+
+Assurez-vous que PostgreSQL tourne et que les chunks existent :
+
+```bash
+# Depuis la racine
+just load     # produit data/chunks/chunks.json
+just embed    # lit les chunks, génère les embeddings, écrit dans pgvector
+```
+
+Vérifier dans la base :
+
+```bash
+docker exec -it rag-postgres psql -U rag -d rag -c "SELECT count(*) FROM document_chunks;"
+```
+
+---
+
+## Epic 5 — Retriever API (hands-on, ~2h30)
+
+### Tâche 5.1 : Comprendre la structure du package
+
+```
+python/rag-retriever/
+├── rag_retriever/
+│   ├── __init__.py          # fourni
+│   ├── main.py              # fourni (projen)
+│   ├── task_inputs.py       # fourni
+│   ├── app.py               # À IMPLÉMENTER
+│   ├── api.py               # À IMPLÉMENTER
+│   ├── dependencies.py      # À IMPLÉMENTER
+│   └── routes/
+│       ├── __init__.py      # fourni
+│       ├── health.py        # À IMPLÉMENTER
+│       ├── search.py        # À IMPLÉMENTER
+│       └── documents.py     # À IMPLÉMENTER
+├── tests/                   # fournis
+├── pyproject.toml           # fourni
+├── justfile                 # fourni
+└── uv.lock                  # fourni
+```
+
+```bash
+cd python/rag-retriever && just install-dev
+just test   # voir ce qui échoue
+```
+
+**TaskInputs fournis** : `host` (0.0.0.0), `port` (8000), `db_url`, `embedding_model`, `top_k` (5).
+
+### Tâche 5.2 : Implémenter les dépendances (DI)
+
+**Fichier** : `python/rag-retriever/rag_retriever/dependencies.py`
+
+Ce module gère les ressources partagées (engine DB + client embedding) comme singletons.
+
+**Variables globales** :
+
+```python
+_engine: AsyncEngine | None = None
+_embedding_client: EmbeddingClient | None = None
+```
+
+**Fonctions à implémenter** :
+
+| Fonction | Rôle |
+|----------|------|
+| `async init_dependencies()` | Initialise `_engine` et `_embedding_client` |
+| `async shutdown_dependencies()` | Dispose `_engine`, remet les globals à `None` |
+| `async get_db_session()` | Générateur async qui yield une `AsyncSession` (commit/rollback) |
+| `get_embedding_client()` | Retourne le client, `RuntimeError` si non initialisé |
+| `async check_db_health()` | Exécute `SELECT 1`, retourne `bool` |
+| `check_model_health()` | Retourne `True` si le client existe |
+
+**Vérification** :
+
+```bash
+just test -- -k test_dependencies   # 7 tests doivent passer
+```
+
+<details>
+<summary>Indice : init_dependencies</summary>
+
+```python
+async def init_dependencies() -> None:
+    global _engine, _embedding_client
+    _engine = get_async_engine(task_inputs.db_url)
+    _embedding_client = EmbeddingClient(task_inputs.embedding_model)
+```
+
+</details>
+
+<details>
+<summary>Indice : get_db_session (générateur async)</summary>
+
+```python
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
+    if _engine is None:
+        raise RuntimeError("Database engine not initialized")
+    async with AsyncSession(_engine) as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+```
+
+</details>
+
+### Tâche 5.3 : Implémenter les endpoints de santé
+
+**Fichier** : `python/rag-retriever/rag_retriever/routes/health.py`
+
+**Endpoints** :
+
+| Méthode | Route | Réponse |
+|---------|-------|---------|
+| GET | `/health` | `{"status": "ok"}` — toujours 200 |
+| GET | `/ready` | Vérifie DB + modèle. 200 si tout OK, 503 sinon |
+
+`/ready` retourne :
+
+```json
+{"status": "ready", "db": true, "model": true}
+```
+
+ou (avec status code 503) :
+
+```json
+{"status": "not_ready", "db": false, "model": true}
+```
+
+**Vérification** :
+
+```bash
+just test -- -k test_health   # 4 tests doivent passer
+```
+
+### Tâche 5.4 : Implémenter POST /search
+
+**Fichier** : `python/rag-retriever/rag_retriever/routes/search.py`
+
+C'est l'endpoint principal du système RAG.
+
+**Signature** :
+
+```python
+@router.post("/search", response_model=SearchResponse)
+async def search(
+    body: SearchRequest,
+    session: AsyncSession = Depends(get_db_session),
+    client: EmbeddingClient = Depends(get_embedding_client),
+) -> SearchResponse:
+```
+
+**Algorithme** :
+1. Encoder la query avec `client.encode([body.query])` → vecteur 384-dim
+2. Mesurer le temps d'embedding (en ms)
+3. Construire la requête SQL pgvector :
+   - `1 - (embedding <=> query_embedding)` comme score de similarité
+   - Filtrer par `similarity >= body.similarity_threshold`
+   - Trier par similarité décroissante
+   - Limiter à `body.top_k`
+4. Mesurer le temps de recherche (en ms)
+5. Construire les `SearchResult` et retourner `SearchResponse`
+
+**Vérification** :
+
+```bash
+just test -- -k test_search   # 5 tests doivent passer
+```
+
+<details>
+<summary>Indice : requête pgvector avec SQLAlchemy</summary>
+
+```python
+import time
+from sqlalchemy import select, literal_column
+
+query_vector = client.encode([body.query])[0]
+similarity = (
+    literal_column("1") - DocumentChunk.embedding.cosine_distance(query_vector)
+).label("similarity_score")
+
+stmt = (
+    select(DocumentChunk, similarity)
+    .where(similarity >= body.similarity_threshold)
+    .order_by(similarity.desc())
+    .limit(body.top_k)
+)
+
+start = time.perf_counter()
+result = await session.execute(stmt)
+rows = result.all()
+search_ms = (time.perf_counter() - start) * 1000
+```
+
+</details>
+
+### Tâche 5.5 : Implémenter GET /documents/stats
+
+**Fichier** : `python/rag-retriever/rag_retriever/routes/documents.py`
+
+**Endpoint** : `GET /documents/stats`
+
+Retourne un `StatsResponse` :
+
+```json
+{
+  "total_documents": 5,
+  "total_chunks": 42,
+  "embedding_dimension": 384,
+  "model_name": "all-MiniLM-L6-v2"
+}
+```
+
+**SQL** : `SELECT count(DISTINCT document_name), count(*) FROM document_chunks`
+
+**Vérification** :
+
+```bash
+just test -- -k test_documents   # 2 tests doivent passer
+```
+
+### Tâche 5.6 : Implémenter l'API factory
+
+**Fichier** : `python/rag-retriever/rag_retriever/api.py`
+
+**Fonctions** :
+
+1. `lifespan(app)` — context manager async qui appelle `init_dependencies()` au démarrage et `shutdown_dependencies()` à l'arrêt
+2. `create_app()` — crée l'app FastAPI avec titre, description, version, lifespan, et enregistre les 3 routers
+
+```python
+from rag_retriever.routes.health import router as health_router
+from rag_retriever.routes.search import router as search_router
+from rag_retriever.routes.documents import router as documents_router
+```
+
+### Tâche 5.7 : Implémenter App.run()
+
+**Fichier** : `python/rag-retriever/rag_retriever/app.py`
+
+Démarre uvicorn en mode factory :
+
+```python
+uvicorn.run(
+    "rag_retriever.api:create_app",
+    host=task_inputs.host,
+    port=task_inputs.port,
+    factory=True,
+)
+```
+
+**Vérification finale** :
+
+```bash
+just test                     # TOUS les tests
+just check-all                # ruff + mypy clean
+```
+
+### Tâche 5.8 : Tester le système complet
+
+```bash
+# Depuis la racine
+just pipeline                 # load + embed
+just serve                    # démarre l'API sur http://localhost:8000
+
+# Dans un autre terminal
+just query "what is MLOps?"
+# ou avec curl :
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "what is MLOps?", "top_k": 5}'
+```
+
+Tester aussi les autres endpoints :
+- `http://localhost:8000/health`
+- `http://localhost:8000/ready`
+- `http://localhost:8000/documents/stats`
+- `http://localhost:8000/docs` (Swagger UI auto-généré par FastAPI)
+
+---
+
+## Récapitulatif Session 2
+
+À la fin de cette session, vous avez :
+
+- [ ] Implémenté `writer.py` — batch upsert dans pgvector
+- [ ] Implémenté `app.py` du rag-embedder — chargement, embedding, sauvegarde
+- [ ] `just embed` insère des vecteurs dans PostgreSQL
+- [ ] Implémenté `dependencies.py` — injection de dépendances FastAPI
+- [ ] Implémenté `routes/health.py` — endpoints /health et /ready
+- [ ] Implémenté `routes/search.py` — recherche sémantique avec pgvector
+- [ ] Implémenté `routes/documents.py` — statistiques
+- [ ] Implémenté `api.py` — application factory FastAPI
+- [ ] `just serve` démarre l'API, `just query` retourne des résultats
+- [ ] `just test-all` passe pour tous les packages
+- [ ] `just check-all` passe pour tous les packages

--- a/course/session-3.md
+++ b/course/session-3.md
@@ -1,0 +1,464 @@
+# Session 3 (7h) — Orchestration Kubernetes
+
+> Kubeflow Pipelines sur Kind : du local au cluster
+
+## Planning
+
+| Horaire | Activité | Type |
+|---------|----------|------|
+| 0:00-0:45 | Crash course Kubernetes + KFP | Cours |
+| 0:45-1:15 | Création du cluster Kind + déploiement KFP | Guidé |
+| 1:15-1:30 | Pause (KFP se déploie en arrière-plan) | |
+| 1:30-2:30 | Epic 6 partie 1 : scaffold rag-pipeline, composants KFP | Hands-on |
+| 2:30-3:30 | Epic 6 partie 2 : définition du pipeline, Dockerfiles | Hands-on |
+| 3:30-3:45 | Pause | |
+| 3:45-5:00 | Epic 6 partie 3 : build images, chargement Kind, soumission | Guidé |
+| 5:00-5:45 | Epic 7 : test d'intégration e2e | Hands-on |
+| 5:45-6:30 | Explorer l'interface KFP, re-lancer le pipeline | Libre |
+| 6:30-7:00 | Récapitulatif du cours, évaluation, Q&A | Cours |
+
+**Livrable** : le pipeline KFP s'exécute sur le cluster Kind, le test e2e passe, l'interface KFP affiche le run.
+
+---
+
+## Crash course Kubernetes + KFP (cours, ~45 min)
+
+### Kubernetes — concepts essentiels
+
+| Concept | Explication |
+|---------|------------|
+| **Pod** | Plus petite unité exécutable. Contient un ou plusieurs conteneurs. |
+| **Service** | Point d'accès réseau stable vers un ensemble de pods. |
+| **Namespace** | Isolation logique dans un cluster (KFP utilise `kubeflow`). |
+| **kubectl** | CLI pour interagir avec le cluster. |
+| **Kind** | Kubernetes IN Docker — un cluster K8s complet dans des conteneurs Docker. |
+
+Commandes utiles :
+
+```bash
+kubectl get pods -n kubeflow          # voir les pods KFP
+kubectl get svc -n kubeflow           # voir les services
+kubectl logs <pod-name> -n kubeflow   # logs d'un pod
+kubectl describe pod <name> -n kubeflow  # détails d'un pod
+```
+
+### Kubeflow Pipelines — concepts essentiels
+
+| Concept | Explication |
+|---------|------------|
+| **Component** | Étape élémentaire = un conteneur Docker avec des entrées/sorties. |
+| **Pipeline** | Graphe acyclique de components avec dépendances de données. |
+| **Artifact** | Donnée produite par un component et consommée par un autre. |
+| **Run** | Exécution d'un pipeline avec des paramètres donnés. |
+| **Compiler** | Traduit le code Python en YAML exécutable par KFP. |
+
+### Architecture du pipeline RAG
+
+```
+┌──────────────┐   JSON chunks   ┌────────────────┐
+│  rag-loader   │───────────────>│  rag-embedder   │
+│  (chunk docs) │   (artifact)   │  (embed+store)  │
+└──────────────┘                 └───────┬────────┘
+                                         │ writes to
+                                         v
+                                 PostgreSQL+pgvector
+                                 (host.docker.internal:5432)
+```
+
+Les pods dans Kind accèdent à PostgreSQL sur l'hôte via `host.docker.internal`.
+
+---
+
+## Création du cluster Kind (guidé, ~30 min)
+
+> **Important** : le déploiement de KFP prend 5-10 minutes. Lancez-le tôt et travaillez sur le code pendant ce temps.
+
+### Étape 1 : Créer le cluster
+
+```bash
+kind create cluster --name rag-kubeflow --config infra/kind-config.yaml --wait 60s
+```
+
+Vérifier :
+
+```bash
+kubectl cluster-info
+kubectl get nodes   # doit montrer 1 nœud "Ready"
+```
+
+### Étape 2 : Déployer KFP
+
+```bash
+# Ressources cluster-scoped
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=2.3.0"
+kubectl wait crd/applications.app.k8s.io --for condition=established --timeout=60s
+
+# Environnement platform-agnostic
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=2.3.0"
+```
+
+Attendre que les pods soient prêts (5-10 min) :
+
+```bash
+kubectl wait pods -l application-crd-id=kubeflow-pipelines -n kubeflow \
+  --for condition=Ready --timeout=600s
+```
+
+Ou surveiller en temps réel :
+
+```bash
+kubectl get pods -n kubeflow -w   # Ctrl+C pour arrêter
+```
+
+### Étape 3 : Accéder à l'interface KFP
+
+```bash
+just kfp-ui   # port-forward vers http://localhost:8080
+```
+
+Ouvrir `http://localhost:8080` dans le navigateur.
+
+> **Alternative rapide** : `just infra-up` fait tout d'un coup (docker-compose + kind + KFP + images).
+
+---
+
+## Epic 6 — Kubeflow Pipeline (hands-on + guidé, ~3h30)
+
+### Tâche 6.1 : Comprendre la structure du package
+
+```
+python/rag-pipeline/
+├── rag_pipeline/
+│   ├── __init__.py          # fourni
+│   ├── main.py              # fourni (projen)
+│   ├── task_inputs.py       # fourni
+│   ├── app.py               # À IMPLÉMENTER
+│   ├── pipeline.py          # À IMPLÉMENTER
+│   └── components/
+│       ├── __init__.py      # fourni
+│       ├── loader.py        # À IMPLÉMENTER
+│       └── embedder.py      # À IMPLÉMENTER
+├── tests/                   # fournis
+├── pyproject.toml           # fourni
+├── justfile                 # fourni
+└── uv.lock                  # fourni
+```
+
+```bash
+cd python/rag-pipeline && just install-dev
+just test   # voir ce qui échoue
+```
+
+**TaskInputs fournis** : `pipeline_name` (rag-ingestion), `input_dir` (data/documents), `kubeflow_host` (http://localhost:8080), `compile_only` (False), `chunk_size` (512), `chunk_overlap` (64), `db_url`, `embedding_model`, `batch_size` (32).
+
+### Tâche 6.2 : Implémenter le composant loader
+
+**Fichier** : `python/rag-pipeline/rag_pipeline/components/loader.py`
+
+Un **container component** KFP encapsule un conteneur Docker comme étape de pipeline.
+
+```python
+from kfp import dsl
+
+LOADER_IMAGE = "rag-loader:local"
+
+@dsl.container_component
+def loader_component(
+    input_dir: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    chunks_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+```
+
+**Comportement** : retourner un `dsl.ContainerSpec` qui :
+1. Utilise l'image `rag-loader:local`
+2. Exécute la commande `["python", "-m", "rag_loader.main"]`
+3. Passe les arguments CLI : `--input-dir`, `--output-dir` (chemin de l'artifact), `--chunk-size`, `--chunk-overlap`
+
+**Vérification** :
+
+```bash
+just test -- -k test_loader   # tests doivent passer
+```
+
+<details>
+<summary>Indice : ContainerSpec</summary>
+
+```python
+return dsl.ContainerSpec(
+    image=LOADER_IMAGE,
+    command=["python", "-m", "rag_loader.main"],
+    args=[
+        "--input-dir", input_dir,
+        "--output-dir", chunks_artifact.path,
+        "--chunk-size", str(chunk_size),
+        "--chunk-overlap", str(chunk_overlap),
+    ],
+)
+```
+
+</details>
+
+### Tâche 6.3 : Implémenter le composant embedder
+
+**Fichier** : `python/rag-pipeline/rag_pipeline/components/embedder.py`
+
+```python
+from kfp import dsl
+
+EMBEDDER_IMAGE = "rag-embedder:local"
+
+@dsl.container_component
+def embedder_component(
+    chunks_artifact: dsl.Input[dsl.Artifact],
+    db_url: str,
+    embedding_model: str,
+    batch_size: int,
+    embeddings_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+```
+
+Même structure que le loader : image `rag-embedder:local`, commande `python -m rag_embedder.main`, arguments CLI.
+
+**Vérification** :
+
+```bash
+just test -- -k test_embedder   # tests doivent passer
+```
+
+### Tâche 6.4 : Implémenter la définition du pipeline
+
+**Fichier** : `python/rag-pipeline/rag_pipeline/pipeline.py`
+
+```python
+from kfp import dsl
+from rag_pipeline.components.embedder import embedder_component
+from rag_pipeline.components.loader import loader_component
+
+@dsl.pipeline(
+    name="RAG Ingestion Pipeline",
+    description="Load documents, chunk, embed, and store in pgvector.",
+)
+def rag_ingestion_pipeline(
+    input_dir: str = "/data/documents",
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+    db_url: str = "postgresql+asyncpg://rag:rag@host.docker.internal:5432/rag",
+    embedding_model: str = "all-MiniLM-L6-v2",
+    batch_size: int = 32,
+) -> None:
+```
+
+**Comportement** :
+1. Appeler `loader_component()` avec `input_dir`, `chunk_size`, `chunk_overlap`
+2. Récupérer l'artifact de sortie du loader (`chunks_artifact`)
+3. Appeler `embedder_component()` avec l'artifact du loader en entrée + `db_url`, `embedding_model`, `batch_size`
+
+Le chaînage des composants via artifacts crée automatiquement la dépendance d'exécution.
+
+**Vérification** :
+
+```bash
+just test -- -k test_pipeline   # 5 tests doivent passer
+```
+
+<details>
+<summary>Indice : chaînage des composants</summary>
+
+```python
+loader_task = loader_component(
+    input_dir=input_dir,
+    chunk_size=chunk_size,
+    chunk_overlap=chunk_overlap,
+)
+
+embedder_component(
+    chunks_artifact=loader_task.outputs["chunks_artifact"],
+    db_url=db_url,
+    embedding_model=embedding_model,
+    batch_size=batch_size,
+)
+```
+
+</details>
+
+### Tâche 6.5 : Implémenter App.run()
+
+**Fichier** : `python/rag-pipeline/rag_pipeline/app.py`
+
+**Méthode à implémenter** : `App.run(self) -> None`
+
+**Comportement** :
+1. Afficher la configuration de `task_inputs`
+2. Compiler le pipeline en YAML avec `kfp.compiler.Compiler().compile()`
+3. Si `compile_only=True` : afficher le chemin du YAML et retourner
+4. Sinon : créer un `kfp.client.Client(host=kubeflow_host)` et soumettre le pipeline
+5. Gérer les erreurs de soumission gracieusement
+
+**Imports** :
+
+```python
+from kfp import compiler, client
+from rag_pipeline.pipeline import rag_ingestion_pipeline
+from rag_pipeline.task_inputs import task_inputs
+```
+
+**Vérification** :
+
+```bash
+just test -- -k test_app       # 2 tests doivent passer
+just test                       # TOUS les tests
+just check-all                  # ruff + mypy clean
+```
+
+### Tâche 6.6 : Créer les Dockerfiles
+
+**Fichier** : `python/rag-loader/Dockerfile`
+
+Structure multi-stage :
+
+```dockerfile
+# --- Builder ---
+FROM python:3.13-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copier les dépendances partagées
+COPY python/lib-schemas python/lib-schemas
+
+# Copier le package
+COPY python/rag-loader python/rag-loader
+
+# Installer
+RUN cd python/rag-loader && uv sync --no-dev --frozen
+
+# --- Runtime ---
+FROM python:3.13-slim
+COPY --from=builder /python/rag-loader/.venv /python/rag-loader/.venv
+COPY --from=builder /python/rag-loader/rag_loader /python/rag-loader/rag_loader
+COPY --from=builder /python/lib-schemas/lib_schemas /python/rag-loader/lib_schemas
+
+# Données sample baked dans l'image
+COPY data/documents /data/documents
+
+ENV PATH="/python/rag-loader/.venv/bin:$PATH"
+ENTRYPOINT ["python", "-m", "rag_loader.main"]
+```
+
+**Fichier** : `python/rag-embedder/Dockerfile`
+
+Même structure, mais avec 3 libs partagées (lib-schemas, lib-embedding, lib-orm).
+
+### Tâche 6.7 : Build + chargement dans Kind
+
+```bash
+# Depuis la racine
+just build-images              # build les 3 images Docker
+just kfp-load-images           # charger loader + embedder dans Kind
+```
+
+Vérifier que les images sont dans le cluster :
+
+```bash
+docker exec rag-kubeflow-control-plane crictl images | grep rag
+```
+
+### Tâche 6.8 : Soumettre le pipeline
+
+```bash
+# Compiler uniquement (pour vérifier le YAML)
+cd python/rag-pipeline
+just run -- --compile-only
+
+# Soumettre au cluster (KFP UI doit être accessible)
+just run
+```
+
+Ouvrir `http://localhost:8080` et observer le pipeline dans l'interface KFP :
+- Vérifier que les deux étapes (loader, embedder) apparaissent
+- Cliquer sur chaque étape pour voir les logs
+- Vérifier que le run est vert (succès)
+
+---
+
+## Epic 7 — Test d'intégration e2e (hands-on, ~45 min)
+
+### Tâche 7.1 : Exécuter le test e2e
+
+Le test d'intégration est **fourni** dans `tests/e2e/test_full_pipeline.py`. Il vérifie le pipeline complet : load → embed → search.
+
+```bash
+# Depuis la racine (PostgreSQL doit tourner)
+just e2e
+```
+
+Le test :
+1. Exécute le loader sur des documents de test
+2. Exécute l'embedder pour vectoriser les chunks
+3. Lance une requête de recherche via l'API
+4. Vérifie que les résultats sont pertinents
+
+### Tâche 7.2 : Déboguer les problèmes éventuels
+
+Problèmes courants et solutions :
+
+| Problème | Solution |
+|----------|---------|
+| `Connection refused` (DB) | Vérifier `docker compose ps` — PostgreSQL doit tourner |
+| `ImagePullBackOff` dans KFP | Les images ne sont pas dans Kind → `just kfp-load-images` |
+| Pipeline timeout | Les pods prennent du temps à démarrer → vérifier `kubectl get pods -n kubeflow` |
+| `host.docker.internal` ne résout pas | Vérifier `infra/kind-config.yaml` — le mapping doit exister |
+
+---
+
+## Explorer l'interface KFP (libre, ~45 min)
+
+Activités suggérées :
+
+1. **Re-lancer le pipeline** avec des paramètres différents (chunk_size, chunk_overlap)
+2. **Explorer les artifacts** : voir le JSON produit par le loader
+3. **Consulter les logs** de chaque étape
+4. **Comparer des runs** avec des paramètres différents
+5. **Vérifier la base** : combien de chunks après un nouveau run ?
+
+```bash
+docker exec -it rag-postgres psql -U rag -d rag -c \
+  "SELECT document_name, count(*) FROM document_chunks GROUP BY document_name;"
+```
+
+---
+
+## Récapitulatif Session 3 (et du cours)
+
+À la fin de cette session, vous avez :
+
+- [ ] Cluster Kind fonctionnel avec KFP
+- [ ] Implémenté les composants KFP (loader + embedder)
+- [ ] Implémenté la définition du pipeline (chaînage via artifacts)
+- [ ] Implémenté App.run() pour compiler et soumettre
+- [ ] Créé les Dockerfiles multi-stage
+- [ ] Chargé les images dans Kind
+- [ ] Soumis et exécuté le pipeline via KFP
+- [ ] Test e2e passe (`just e2e`)
+- [ ] `just test-all` passe pour tous les packages
+- [ ] `just check-all` passe pour tous les packages
+
+### Ce que vous avez construit en 21 heures
+
+```
+Documents .md/.txt
+    │
+    ▼
+[rag-loader]  ──── chunk_text() ────> chunks.json
+    │                                      │
+    │              KFP Pipeline (Kind)     │
+    ▼                                      ▼
+[rag-embedder] ── encode() + upsert ──> PostgreSQL+pgvector
+                                              │
+                                              ▼
+                                        [rag-retriever]
+                                         POST /search
+                                         FastAPI :8000
+```
+
+Un système RAG complet, orchestré par Kubernetes, avec tests, linting, et typage strict.

--- a/course/setup-guide.md
+++ b/course/setup-guide.md
@@ -1,0 +1,170 @@
+# Guide d'installation — Pré-requis
+
+> A effectuer **avant** la première séance. Comptez 30-45 minutes.
+
+## 1. Docker Desktop
+
+Télécharger et installer Docker Desktop :
+- **Windows** : https://docs.docker.com/desktop/install/windows-install/
+- **macOS** : https://docs.docker.com/desktop/install/mac-install/
+- **Linux** : https://docs.docker.com/desktop/install/linux/
+
+Vérifier :
+
+```bash
+docker --version        # Docker version 27.x ou plus récent
+docker compose version  # Docker Compose version v2.x
+```
+
+> **Windows** : activer WSL 2 si ce n'est pas déjà fait. Docker Desktop le propose à l'installation.
+
+## 2. Python 3.13+
+
+Installer Python 3.13 ou plus récent :
+- **Windows** : https://www.python.org/downloads/ (cocher "Add to PATH")
+- **macOS** : `brew install python@3.13`
+- **Linux** : `sudo apt install python3.13` ou via pyenv
+
+Vérifier :
+
+```bash
+python --version   # Python 3.13.x
+```
+
+## 3. uv (gestionnaire de paquets Python)
+
+```bash
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Vérifier :
+
+```bash
+uv --version   # uv 0.6.x ou plus récent
+```
+
+## 4. kind (Kubernetes in Docker)
+
+```bash
+# Windows (PowerShell)
+choco install kind
+# ou télécharger depuis https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+
+# macOS
+brew install kind
+
+# Linux
+go install sigs.k8s.io/kind@latest
+# ou télécharger le binaire
+```
+
+Vérifier :
+
+```bash
+kind --version   # kind v0.25.x ou plus récent
+```
+
+## 5. kubectl
+
+```bash
+# Windows (PowerShell)
+choco install kubernetes-cli
+
+# macOS
+brew install kubectl
+
+# Linux
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+```
+
+Vérifier :
+
+```bash
+kubectl version --client   # Client Version: v1.31.x ou plus récent
+```
+
+## 6. Git + compte GitHub
+
+Git est probablement déjà installé. Sinon :
+- **Windows** : https://git-scm.com/download/win
+- **macOS** : `xcode-select --install`
+- **Linux** : `sudo apt install git`
+
+Vérifier :
+
+```bash
+git --version   # git version 2.x
+```
+
+Vous aurez besoin d'un **compte GitHub** pour forker le repository template.
+
+## 7. just (task runner)
+
+```bash
+# Windows (PowerShell)
+choco install just
+# ou : cargo install just
+
+# macOS
+brew install just
+
+# Linux
+cargo install just
+# ou via les packages de votre distribution
+```
+
+Vérifier :
+
+```bash
+just --version   # just 1.x
+```
+
+## 8. VS Code (recommandé)
+
+Télécharger : https://code.visualstudio.com/
+
+Extensions recommandées :
+- **Python** (Microsoft)
+- **Ruff** (Astral Software)
+- **Even Better TOML** (tamasfe)
+
+## Checklist finale
+
+Exécuter ces commandes pour vérifier que tout est prêt :
+
+```bash
+docker --version          # ✓
+python --version          # ✓ >= 3.13
+uv --version              # ✓
+kind --version            # ✓
+kubectl version --client  # ✓
+git --version             # ✓
+just --version            # ✓
+```
+
+## Premier lancement (en séance)
+
+Le jour de la première séance, vous ferez :
+
+```bash
+# 1. Cloner le repository
+git clone https://github.com/<org>/rag-kubeflow-starter.git
+cd rag-kubeflow-starter
+
+# 2. Démarrer PostgreSQL
+docker compose up -d
+
+# 3. Installer les dépendances du premier package
+cd python/rag-loader
+just install-dev
+
+# 4. Lancer les tests (ils échoueront — c'est normal !)
+just test
+```
+
+> **Attention** : le premier `just install-dev` téléchargera le modèle d'embedding (`all-MiniLM-L6-v2`, ~80 Mo). Prévoyez une connexion internet.

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@
 set shell := ["powershell", "-NoProfile", "-Command"]
 
 # KFP manifest version for standalone deployment
-KFP_VERSION := "2.3.0"
+KFP_VERSION := "2.16.0"
 # Kind cluster name
 KIND_CLUSTER := "rag-kubeflow"
 
@@ -14,8 +14,20 @@ default:
 
 # --- Infrastructure ---
 
+# Start Docker Desktop (waits until daemon is ready)
+docker-start:
+    @if (-not (Get-Process "Docker Desktop" -ErrorAction SilentlyContinue)) { \
+        Write-Host "Starting Docker Desktop..." -ForegroundColor Cyan; \
+        Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe"; \
+    } else { \
+        Write-Host "Docker Desktop already running." -ForegroundColor Green; \
+    }
+    @Write-Host "Waiting for Docker daemon..." -ForegroundColor Yellow
+    @while (-not (docker info 2>$null)) { Start-Sleep -Seconds 2 }
+    @Write-Host "Docker is ready." -ForegroundColor Green
+
 # Start all infrastructure: PostgreSQL, Kind cluster, KFP, load images
-infra-up:
+infra-up: docker-start
     @Write-Host "Starting PostgreSQL..." -ForegroundColor Cyan
     docker compose up -d
     @Write-Host "Creating Kind cluster '{{KIND_CLUSTER}}'..." -ForegroundColor Cyan
@@ -92,6 +104,26 @@ build-images:
     docker build -t rag-loader:latest -t rag-loader:local -f python/rag-loader/Dockerfile .
     docker build -t rag-embedder:latest -t rag-embedder:local -f python/rag-embedder/Dockerfile .
     docker build -t rag-retriever:latest -f python/rag-retriever/Dockerfile .
+
+# --- RAG Pipeline (local) ---
+
+# Run the loader (chunk documents → JSON)
+load:
+    @Write-Host "Running rag-loader..." -ForegroundColor Cyan
+    Push-Location python/rag-loader; uv run main --input-dir ../../data/documents; Pop-Location
+
+# Run the embedder (embed chunks → pgvector)
+embed:
+    @Write-Host "Running rag-embedder..." -ForegroundColor Cyan
+    Push-Location python/rag-embedder; uv run main; Pop-Location
+
+# Run the full local pipeline: loader then embedder
+pipeline: load embed
+
+# Submit the pipeline to KFP (requires 'just kfp-ui' running in another terminal)
+kfp-submit:
+    @Write-Host "Submitting pipeline to KFP..." -ForegroundColor Cyan
+    Push-Location python/rag-pipeline; uv run main; Pop-Location
 
 # --- RAG Retriever ---
 

--- a/scripts/create-starter-repo.sh
+++ b/scripts/create-starter-repo.sh
@@ -1,0 +1,830 @@
+#!/usr/bin/env bash
+# create-starter-repo.sh
+#
+# Creates the student starter repository from the reference solution.
+# Copies all scaffolding as-is, copies lib-* packages as-is,
+# and replaces business logic in service packages with skeleton stubs.
+#
+# Usage:
+#   ./scripts/create-starter-repo.sh [output_dir]
+#   Default output: ../rag-kubeflow-starter
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT_DIR="${1:-$(cd "$SRC_DIR/.." && pwd)/rag-kubeflow-starter}"
+
+echo "=== Creating starter repo ==="
+echo "Source:  $SRC_DIR"
+echo "Output:  $OUT_DIR"
+echo ""
+
+# Directories to exclude from all copies
+EXCLUDES=(.venv __pycache__ .mypy_cache .pytest_cache .ruff_cache node_modules .git)
+
+# rsync-like copy that skips EXCLUDES
+# Uses tar pipe to handle excludes portably (no rsync on Git Bash by default)
+copy_filtered() {
+    local src="$1" dst="$2"
+    mkdir -p "$dst"
+    local exclude_args=()
+    for ex in "${EXCLUDES[@]}"; do
+        exclude_args+=(--exclude="$ex")
+    done
+    tar cf - -C "$(dirname "$src")" "${exclude_args[@]}" "$(basename "$src")" \
+        | tar xf - -C "$(dirname "$dst")"
+}
+
+# Clean output directory (cmd fallback for Windows file locking)
+rm -rf "$OUT_DIR" 2>/dev/null
+if [ -d "$OUT_DIR" ] && command -v cmd &>/dev/null; then
+    cmd //c "rmdir /s /q $(cygpath -w "$OUT_DIR")" 2>/dev/null
+fi
+mkdir -p "$OUT_DIR"
+
+# ── 1. Copy root scaffolding as-is ──────────────────────────────────────────
+
+echo "Copying root scaffolding..."
+for f in \
+    docker-compose.yml \
+    pyproject.toml \
+    justfile \
+    .pre-commit-config.yaml \
+    .gitignore \
+    .python-version
+do
+    [ -f "$SRC_DIR/$f" ] && cp "$SRC_DIR/$f" "$OUT_DIR/$f"
+done
+
+# Copy directories
+for d in infra data course specs; do
+    [ -d "$SRC_DIR/$d" ] && cp -r "$SRC_DIR/$d" "$OUT_DIR/$d"
+done
+
+# Copy e2e tests
+mkdir -p "$OUT_DIR/tests/e2e"
+cp -r "$SRC_DIR/tests/e2e/"* "$OUT_DIR/tests/e2e/" 2>/dev/null || true
+[ -f "$SRC_DIR/tests/__init__.py" ] && cp "$SRC_DIR/tests/__init__.py" "$OUT_DIR/tests/"
+
+# ── 2. Copy lib-* packages as-is (complete implementation) ──────────────────
+
+echo "Copying shared libraries (complete)..."
+mkdir -p "$OUT_DIR/python"
+for lib in lib-schemas lib-embedding lib-orm; do
+    [ -d "$SRC_DIR/python/$lib" ] && copy_filtered "$SRC_DIR/python/$lib" "$OUT_DIR/python/$lib"
+done
+
+# Copy package-1 template
+[ -d "$SRC_DIR/python/package-1" ] && copy_filtered "$SRC_DIR/python/package-1" "$OUT_DIR/python/package-1"
+
+# ── 3. Copy service packages with skeleton stubs ────────────────────────────
+
+# Helper: copy the full package, then replace specific files with stubs
+copy_package_scaffold() {
+    local pkg="$1"
+    local pkg_dir="$SRC_DIR/python/$pkg"
+    local out_pkg="$OUT_DIR/python/$pkg"
+
+    if [ ! -d "$pkg_dir" ]; then
+        echo "  SKIP $pkg (not found)"
+        return
+    fi
+
+    echo "  Scaffolding $pkg..."
+
+    # Copy everything (excluding .venv, caches, etc.)
+    copy_filtered "$pkg_dir" "$out_pkg"
+}
+
+echo "Creating service package skeletons..."
+
+# ── rag-loader ──
+
+copy_package_scaffold "rag-loader"
+
+cat > "$OUT_DIR/python/rag-loader/rag_loader/reader.py" << 'STUB'
+"""Document reader module for rag-loader."""
+
+from pathlib import Path
+
+SUPPORTED_EXTENSIONS = {".txt", ".md"}
+
+
+def read_documents(input_dir: str) -> list[dict[str, object]]:
+    """
+    Read all supported text files from a directory.
+
+    Reads ``.txt`` and ``.md`` files (non-recursive) and returns their
+    content along with metadata.
+
+    Parameters
+    ----------
+    input_dir : str
+        Path to the directory containing documents.
+
+    Returns
+    -------
+    list[dict[str, object]]
+        List of dicts with keys ``document_name``, ``content``, ``metadata``.
+        Metadata contains ``file_size`` (int) and ``extension`` (str).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``input_dir`` does not exist.
+    NotADirectoryError
+        If ``input_dir`` is not a directory.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-loader/rag_loader/chunker.py" << 'STUB'
+"""Recursive character text splitter for rag-loader."""
+
+SEPARATORS = ["\n\n", "\n", ". ", " ", ""]
+
+
+def chunk_text(text: str, chunk_size: int = 512, chunk_overlap: int = 64) -> list[str]:
+    """
+    Split text into overlapping chunks using a recursive character strategy.
+
+    Tries separators in order (paragraph, newline, sentence, word, character)
+    and falls back to the next separator when a segment exceeds ``chunk_size``.
+
+    Parameters
+    ----------
+    text : str
+        The input text to split.
+    chunk_size : int
+        Maximum number of characters per chunk.
+    chunk_overlap : int
+        Number of overlapping characters between consecutive chunks.
+
+    Returns
+    -------
+    list[str]
+        List of text chunks.
+
+    Raises
+    ------
+    ValueError
+        If ``chunk_overlap`` is greater than or equal to ``chunk_size``.
+    """
+    raise NotImplementedError  # TODO: implement
+
+
+def _split_recursive(text: str, chunk_size: int, sep_idx: int) -> list[str]:
+    """
+    Recursively split text using the separator hierarchy.
+
+    Parameters
+    ----------
+    text : str
+        Text to split.
+    chunk_size : int
+        Maximum chunk size.
+    sep_idx : int
+        Current index into the ``SEPARATORS`` list.
+
+    Returns
+    -------
+    list[str]
+        List of text segments.
+    """
+    raise NotImplementedError  # TODO: implement
+
+
+def _merge_with_overlap(segments: list[str], chunk_size: int, chunk_overlap: int) -> list[str]:
+    """
+    Merge small segments into chunks and add overlap between them.
+
+    Parameters
+    ----------
+    segments : list[str]
+        Text segments to merge.
+    chunk_size : int
+        Maximum chunk size.
+    chunk_overlap : int
+        Target overlap between consecutive chunks.
+
+    Returns
+    -------
+    list[str]
+        Merged chunks with overlap.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-loader/rag_loader/app.py" << 'STUB'
+"""Application module for rag-loader."""
+
+
+class App:
+    """Document loader application for RAG system."""
+
+    def run(self) -> None:
+        """
+        Run the document loader.
+
+        Read documents from ``input_dir``, chunk them, and write JSON to ``output_dir``.
+        """
+        raise NotImplementedError  # TODO: implement
+STUB
+
+# ── rag-embedder ──
+
+copy_package_scaffold "rag-embedder"
+
+cat > "$OUT_DIR/python/rag-embedder/rag_embedder/writer.py" << 'STUB'
+"""Batch writer for pgvector storage."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lib_schemas.schemas import ChunkWithEmbedding
+
+
+async def write_chunks(session: AsyncSession, chunks: list[ChunkWithEmbedding]) -> int:
+    """
+    Write embedding chunks to the database with upsert logic.
+
+    For each chunk, look up an existing ``DocumentChunk`` by
+    ``(document_name, chunk_index)``. If found, update it in place.
+    If not found, create a new row.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        SQLAlchemy async session.
+    chunks : list[ChunkWithEmbedding]
+        Chunks with embeddings to write.
+
+    Returns
+    -------
+    int
+        Number of rows affected (inserted or updated).
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-embedder/rag_embedder/app.py" << 'STUB'
+"""Application module for rag-embedder."""
+
+
+class App:
+    """Batch embedding and storage application for RAG system."""
+
+    def run(self) -> None:
+        """
+        Run the embedder.
+
+        Load chunks from JSON, generate embeddings, save to JSON and database.
+        """
+        raise NotImplementedError  # TODO: implement
+
+    @staticmethod
+    async def _write_to_db(results: list) -> None:
+        """
+        Write embedding results to the database.
+
+        Parameters
+        ----------
+        results : list
+            List of ``ChunkWithEmbedding`` objects.
+        """
+        raise NotImplementedError  # TODO: implement
+STUB
+
+# ── rag-retriever ──
+
+copy_package_scaffold "rag-retriever"
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/dependencies.py" << 'STUB'
+"""FastAPI dependency injection and shared resource management."""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from lib_embedding.embedding import EmbeddingClient
+
+_engine: AsyncEngine | None = None
+_embedding_client: EmbeddingClient | None = None
+
+
+async def init_dependencies() -> None:
+    """Initialize the database engine and embedding client."""
+    raise NotImplementedError  # TODO: implement
+
+
+async def shutdown_dependencies() -> None:
+    """Dispose the database engine and release resources."""
+    raise NotImplementedError  # TODO: implement
+
+
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
+    """
+    Yield an async database session.
+
+    Commits on success, rolls back on error.
+
+    Yields
+    ------
+    AsyncSession
+        An active database session.
+
+    Raises
+    ------
+    RuntimeError
+        If the database engine has not been initialized.
+    """
+    raise NotImplementedError  # TODO: implement
+    yield  # type: ignore[misc]  # make it a generator
+
+
+def get_embedding_client() -> EmbeddingClient:
+    """
+    Return the pre-loaded embedding client.
+
+    Returns
+    -------
+    EmbeddingClient
+        The embedding client singleton.
+
+    Raises
+    ------
+    RuntimeError
+        If the embedding client has not been initialized.
+    """
+    raise NotImplementedError  # TODO: implement
+
+
+async def check_db_health() -> bool:
+    """
+    Check database connectivity by executing ``SELECT 1``.
+
+    Returns
+    -------
+    bool
+        True if the database is reachable.
+    """
+    raise NotImplementedError  # TODO: implement
+
+
+def check_model_health() -> bool:
+    """
+    Check whether the embedding model is loaded.
+
+    Returns
+    -------
+    bool
+        True if ``_embedding_client`` is not None.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/api.py" << 'STUB'
+"""FastAPI application factory."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """
+    Manage application lifespan: init and shutdown dependencies.
+
+    Parameters
+    ----------
+    app : FastAPI
+        The FastAPI application instance.
+
+    Yields
+    ------
+    None
+    """
+    raise NotImplementedError  # TODO: implement
+    yield  # type: ignore[misc]
+
+
+def create_app() -> FastAPI:
+    """
+    Create and configure the FastAPI application.
+
+    Returns
+    -------
+    FastAPI
+        Configured application with routers and lifespan.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+mkdir -p "$OUT_DIR/python/rag-retriever/rag_retriever/routes"
+[ -f "$SRC_DIR/python/rag-retriever/rag_retriever/routes/__init__.py" ] && \
+    cp "$SRC_DIR/python/rag-retriever/rag_retriever/routes/__init__.py" \
+       "$OUT_DIR/python/rag-retriever/rag_retriever/routes/__init__.py"
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/routes/health.py" << 'STUB'
+"""Health and readiness probe endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, Response
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """
+    Return a simple health check.
+
+    Returns
+    -------
+    dict[str, str]
+        Always ``{"status": "ok"}``.
+    """
+    raise NotImplementedError  # TODO: implement
+
+
+@router.get("/ready")
+async def ready(response: Response) -> dict[str, Any]:
+    """
+    Check readiness of database and embedding model.
+
+    Returns 200 if all healthy, 503 otherwise.
+
+    Parameters
+    ----------
+    response : Response
+        FastAPI response object (to set status code).
+
+    Returns
+    -------
+    dict[str, Any]
+        Dict with keys ``status``, ``db``, ``model``.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/routes/search.py" << 'STUB'
+"""Semantic search endpoint."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lib_embedding.embedding import EmbeddingClient
+from lib_schemas.schemas import SearchRequest, SearchResponse
+
+from rag_retriever.dependencies import get_db_session, get_embedding_client
+
+router = APIRouter()
+
+
+@router.post("/search", response_model=SearchResponse)
+async def search(
+    body: SearchRequest,
+    session: AsyncSession = Depends(get_db_session),
+    client: EmbeddingClient = Depends(get_embedding_client),
+) -> SearchResponse:
+    """
+    Perform semantic search against pgvector.
+
+    Encode the query, search by cosine similarity, return ranked results.
+
+    Parameters
+    ----------
+    body : SearchRequest
+        Search parameters (query, top_k, similarity_threshold).
+    session : AsyncSession
+        Database session (injected).
+    client : EmbeddingClient
+        Embedding client (injected).
+
+    Returns
+    -------
+    SearchResponse
+        Ranked search results with timing information.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/routes/documents.py" << 'STUB'
+"""Document statistics endpoint."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lib_schemas.schemas import StatsResponse
+
+from rag_retriever.dependencies import get_db_session
+
+router = APIRouter(prefix="/documents")
+
+
+@router.get("/stats", response_model=StatsResponse)
+async def stats(
+    session: AsyncSession = Depends(get_db_session),
+) -> StatsResponse:
+    """
+    Return document and chunk statistics.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    StatsResponse
+        Total documents, chunks, embedding dimension, and model name.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-retriever/rag_retriever/app.py" << 'STUB'
+"""Application module for rag-retriever."""
+
+
+class App:
+    """RAG retriever API application."""
+
+    def run(self) -> None:
+        """
+        Run the retriever API server.
+
+        Start uvicorn with the FastAPI app factory.
+        """
+        raise NotImplementedError  # TODO: implement
+STUB
+
+# ── rag-pipeline ──
+
+copy_package_scaffold "rag-pipeline"
+
+mkdir -p "$OUT_DIR/python/rag-pipeline/rag_pipeline/components"
+[ -f "$SRC_DIR/python/rag-pipeline/rag_pipeline/components/__init__.py" ] && \
+    cp "$SRC_DIR/python/rag-pipeline/rag_pipeline/components/__init__.py" \
+       "$OUT_DIR/python/rag-pipeline/rag_pipeline/components/__init__.py"
+
+cat > "$OUT_DIR/python/rag-pipeline/rag_pipeline/components/loader.py" << 'STUB'
+"""KFP container component for the document loader."""
+
+from kfp import dsl
+
+LOADER_IMAGE = "rag-loader:local"
+
+
+@dsl.container_component
+def loader_component(
+    input_dir: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    chunks_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+    """
+    KFP component that runs rag-loader in a container.
+
+    Parameters
+    ----------
+    input_dir : str
+        Path to documents inside the container.
+    chunk_size : int
+        Maximum characters per chunk.
+    chunk_overlap : int
+        Overlap between consecutive chunks.
+    chunks_artifact : dsl.Output[dsl.Artifact]
+        Output artifact for chunked JSON.
+
+    Returns
+    -------
+    dsl.ContainerSpec
+        Container specification for the loader.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-pipeline/rag_pipeline/components/embedder.py" << 'STUB'
+"""KFP container component for the embedder."""
+
+from kfp import dsl
+
+EMBEDDER_IMAGE = "rag-embedder:local"
+
+
+@dsl.container_component
+def embedder_component(
+    chunks_artifact: dsl.Input[dsl.Artifact],
+    db_url: str,
+    embedding_model: str,
+    batch_size: int,
+    embeddings_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+    """
+    KFP component that runs rag-embedder in a container.
+
+    Parameters
+    ----------
+    chunks_artifact : dsl.Input[dsl.Artifact]
+        Input artifact from the loader (chunked JSON).
+    db_url : str
+        PostgreSQL connection string.
+    embedding_model : str
+        Sentence-transformers model name.
+    batch_size : int
+        Batch size for embedding.
+    embeddings_artifact : dsl.Output[dsl.Artifact]
+        Output artifact for embeddings JSON.
+
+    Returns
+    -------
+    dsl.ContainerSpec
+        Container specification for the embedder.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-pipeline/rag_pipeline/pipeline.py" << 'STUB'
+"""KFP pipeline definition for RAG ingestion."""
+
+from kfp import dsl
+
+from rag_pipeline.components.embedder import embedder_component
+from rag_pipeline.components.loader import loader_component
+
+
+@dsl.pipeline(
+    name="RAG Ingestion Pipeline",
+    description="Load documents, chunk, embed, and store in pgvector.",
+)
+def rag_ingestion_pipeline(
+    input_dir: str = "/data/documents",
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+    db_url: str = "postgresql+asyncpg://rag:rag@host.docker.internal:5432/rag",
+    embedding_model: str = "all-MiniLM-L6-v2",
+    batch_size: int = 32,
+) -> None:
+    """
+    RAG ingestion pipeline: loader -> embedder.
+
+    Parameters
+    ----------
+    input_dir : str
+        Path to documents inside the loader container.
+    chunk_size : int
+        Maximum characters per chunk.
+    chunk_overlap : int
+        Overlap between consecutive chunks.
+    db_url : str
+        PostgreSQL connection string (use host.docker.internal for Kind).
+    embedding_model : str
+        Sentence-transformers model name.
+    batch_size : int
+        Batch size for embedding.
+    """
+    raise NotImplementedError  # TODO: implement
+STUB
+
+cat > "$OUT_DIR/python/rag-pipeline/rag_pipeline/app.py" << 'STUB'
+"""Application module for rag-pipeline."""
+
+PIPELINE_YAML = "rag-ingestion-pipeline.yaml"
+
+
+class App:
+    """Pipeline compiler and submitter application."""
+
+    def run(self) -> None:
+        """
+        Compile and optionally submit the KFP pipeline.
+
+        If ``compile_only`` is True, writes YAML and exits.
+        Otherwise, submits the pipeline to the KFP cluster.
+        """
+        raise NotImplementedError  # TODO: implement
+STUB
+
+# ── 4. Remove solution-specific files ───────────────────────────────────────
+
+echo "Cleaning up..."
+
+# Remove CLAUDE.md (reference-repo specific)
+rm -f "$OUT_DIR/CLAUDE.md"
+
+# Remove .claude directory (reference-repo specific)
+rm -rf "$OUT_DIR/.claude"
+
+# Remove specs/decisions.md and specs/epics.md (reference-only)
+# Keep other specs as student reference material
+
+# Remove data/chunks and data/embeddings (generated output)
+rm -rf "$OUT_DIR/data/chunks" "$OUT_DIR/data/embeddings"
+
+# ── 5. Create starter README ───────────────────────────────────────────────
+
+cat > "$OUT_DIR/README.md" << 'README'
+# RAG Kubeflow — Starter Template
+
+Système RAG (Retrieval-Augmented Generation) avec FastAPI, PostgreSQL+pgvector et Kubeflow Pipelines.
+
+## Démarrage rapide
+
+```bash
+# 1. Installer les outils (voir course/setup-guide.md)
+# 2. Démarrer PostgreSQL
+docker compose up -d
+
+# 3. Installer les dépendances du premier package
+cd python/rag-loader && just install-dev
+
+# 4. Lancer les tests (ils échoueront — c'est normal !)
+just test
+```
+
+## Structure
+
+```
+python/
+├── lib-schemas/       # Schémas Pydantic partagés (fourni)
+├── lib-embedding/     # Client d'embedding (fourni)
+├── lib-orm/           # ORM asynchrone (fourni)
+├── rag-loader/        # À implémenter (Session 1)
+├── rag-embedder/      # À implémenter (Session 2)
+├── rag-retriever/     # À implémenter (Session 2)
+└── rag-pipeline/      # À implémenter (Session 3)
+```
+
+## Guides de session
+
+- [Guide d'installation](course/setup-guide.md)
+- [Session 1 — Fondations](course/session-1.md)
+- [Session 2 — Embedding et API](course/session-2.md)
+- [Session 3 — Orchestration Kubernetes](course/session-3.md)
+
+## Commandes utiles
+
+```bash
+just --list            # voir toutes les recettes
+just load              # exécuter le loader
+just embed             # exécuter l'embedder
+just pipeline          # load + embed
+just serve             # démarrer l'API (http://localhost:8000)
+just query "question"  # interroger l'API
+just test-all          # tests de tous les packages
+just check-all         # lint + typecheck
+just e2e               # test d'intégration
+```
+README
+
+# ── 6. Summary ──────────────────────────────────────────────────────────────
+
+# ── 6. Git init + GitHub push ───────────────────────────────────────────────
+
+REPO_NAME="${GITHUB_REPO_NAME:-rag-kubeflow-starter}"
+GITHUB_ORG="${GITHUB_ORG:-iglesial}"
+
+echo "Initializing git repo..."
+cd "$OUT_DIR"
+git init -b main
+git add -A
+git commit -m "Initial starter template"
+
+if command -v gh &>/dev/null; then
+    echo ""
+    echo "Creating GitHub repo '$REPO_NAME' (public, template)..."
+    if [ -n "$GITHUB_ORG" ]; then
+        gh repo create "$GITHUB_ORG/$REPO_NAME" --public --source=. --push
+    else
+        gh repo create "$REPO_NAME" --public --source=. --push
+    fi
+    # Mark as template repo
+    OWNER=$(gh repo view --json owner -q '.owner.login')
+    gh api -X PATCH "repos/$OWNER/$REPO_NAME" -f is_template=true
+    echo ""
+    echo "=== Done! ==="
+    gh repo view --web 2>/dev/null || echo "Repo: https://github.com/$OWNER/$REPO_NAME"
+else
+    echo ""
+    echo "=== Starter repo created (local only — gh CLI not found) ==="
+    echo "Location: $OUT_DIR"
+    echo "To push manually:"
+    echo "  cd $OUT_DIR"
+    echo "  gh repo create $REPO_NAME --public --source=. --push"
+fi
+
+echo ""
+echo "Given complete:"
+echo "  - docker-compose.yml, infra/, .pre-commit-config.yaml"
+echo "  - python/lib-schemas/, python/lib-embedding/, python/lib-orm/"
+echo "  - tests/ (all test suites)"
+echo "  - course/ (session guides + fiche de cours)"
+echo ""
+echo "Skeleton stubs (students implement):"
+echo "  - python/rag-loader/rag_loader/{reader,chunker,app}.py"
+echo "  - python/rag-embedder/rag_embedder/{writer,app}.py"
+echo "  - python/rag-retriever/rag_retriever/{api,dependencies,app,routes/*}.py"
+echo "  - python/rag-pipeline/rag_pipeline/{pipeline,app,components/*}.py"


### PR DESCRIPTION
## Summary

- Add French course description (`course/fiche-de-cours.md`) — 21h TP across 3 sessions
- Add session guides (`course/session-{1,2,3}.md`) with step-by-step tasks, code hints, and verification commands
- Add pre-course setup guide (`course/setup-guide.md`)
- Add `scripts/create-starter-repo.sh` that generates a GitHub template repo with skeleton stubs
- Excludes `.venv` and caches from copy using tar pipe with `--exclude`
- Add `load`, `embed`, `pipeline`, `docker-start` recipes to root justfile

## Test plan

- [x] Run `bash scripts/create-starter-repo.sh` — created https://github.com/iglesial/rag-kubeflow-starter
- [ ] Review fiche-de-cours.md for completeness
- [ ] Review session guides for accuracy against reference implementation
- [ ] Verify `just load`, `just embed`, `just pipeline` work from root justfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)