### PR TITLE
feat: add reveal.js slide decks for sessions 1-3

### DIFF
--- a/course/slides/session-1-slides.html
+++ b/course/slides/session-1-slides.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Session 1 — Fondations</title>
+<link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reset.css">
+<link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reveal.css">
+<link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/theme/moon.css">
+<link rel="stylesheet" href="https://unpkg.com/reveal.js@5/plugin/highlight/monokai.css">
+<style>
+  .reveal pre code {
+    max-height: 500px;
+    font-size: 0.45em;
+    line-height: 1.4;
+  }
+  .reveal table {
+    font-size: 0.6em;
+  }
+  .reveal table th,
+  .reveal table td {
+    border: 1px solid #555;
+    padding: 0.3em 0.6em;
+  }
+  .reveal table thead th {
+    border-bottom: 2px solid #aaa;
+  }
+  .reveal li {
+    font-size: 0.75em;
+  }
+  .task-title {
+    color: #4fc3f7 !important;
+  }
+  .reveal pre.tree-block {
+    font-size: 0.45em;
+    line-height: 1.4;
+  }
+  .reveal pre.tree-block code {
+    max-height: 500px;
+  }
+  .reveal .hint-label {
+    color: #ffb74d;
+    font-weight: bold;
+  }
+  .reveal section p {
+    font-size: 0.75em;
+  }
+  .reveal section ul {
+    display: block;
+  }
+  .reveal blockquote {
+    font-size: 0.7em;
+    width: 90%;
+  }
+  .reveal h2 {
+    font-size: 1.4em;
+  }
+  .reveal h3 {
+    font-size: 1.1em;
+  }
+</style>
+</head>
+<body>
+<div class="reveal">
+<div class="slides">
+
+<!-- ============================================ -->
+<!-- TITLE SLIDE                                   -->
+<!-- ============================================ -->
+<section>
+  <h1>Session 1 — Fondations</h1>
+  <h3>Infrastructure, bibliothèques partagées et document loader</h3>
+  <p><em>RAG Retrieval System — MLOps avec Kubeflow</em></p>
+</section>
+
+<!-- ============================================ -->
+<!-- PLANNING                                      -->
+<!-- ============================================ -->
+<section>
+  <h2>Planning</h2>
+  <table>
+    <thead>
+      <tr><th>Horaire</th><th>Activité</th><th>Type</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0:00-0:45</td><td>Introduction, architecture, vérification de l'environnement</td><td>Cours</td></tr>
+      <tr><td>0:45-1:15</td><td>Epic 1 : pre-commit, docker-compose, justfile</td><td>Guidé</td></tr>
+      <tr><td>1:15-1:30</td><td>Pause</td><td></td></tr>
+      <tr><td>1:30-2:00</td><td>Démo : patron package-1, Pydantic BaseSettings</td><td>Cours</td></tr>
+      <tr><td>2:00-3:30</td><td>Epic 2 : découverte des bibliothèques partagées (fournies)</td><td>Lecture + exploration</td></tr>
+      <tr><td>3:30-3:45</td><td>Pause</td><td></td></tr>
+      <tr><td>3:45-5:45</td><td>Epic 3 : implémentation de rag-loader</td><td>Hands-on</td></tr>
+      <tr><td>5:45-6:30</td><td>Exécution de <code>just load</code>, vérification du JSON, tests</td><td>Hands-on</td></tr>
+      <tr><td>6:30-7:00</td><td>Récapitulatif + Q&amp;A</td><td>Cours</td></tr>
+    </tbody>
+  </table>
+  <p><strong>Livrable</strong> : <code>just load</code> produit un fichier <code>data/chunks/chunks.json</code>. Tous les tests passent.</p>
+</section>
+
+<!-- ============================================ -->
+<!-- EPIC 1 — INFRASTRUCTURE                       -->
+<!-- ============================================ -->
+<section>
+  <h2>Epic 1 — Infrastructure</h2>
+  <p>(guidé, ~30 min)</p>
+  <p>Ces fichiers sont <strong>fournis dans le template</strong>. L'enseignant les parcourt avec les étudiants.</p>
+</section>
+
+<!-- TACHE 1.1 -->
+<section>
+  <h3 class="task-title">Tâche 1.1 : Vérifier l'environnement</h3>
+  <pre><code class="language-bash" data-trim>
+docker --version          # Docker Desktop installé
+python --version          # >= 3.13
+uv --version              # uv installé
+kind --version            # kind installé
+kubectl version --client  # kubectl installé
+git --version             # git installé
+  </code></pre>
+</section>
+
+<!-- TACHE 1.2 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 1.2 : Démarrer PostgreSQL</h3>
+    <pre><code class="language-bash" data-trim>
+docker compose up -d
+docker compose ps          # postgres healthy
+    </code></pre>
+    <p>Vérifier la connexion :</p>
+    <pre><code class="language-bash" data-trim>
+docker exec -it rag-postgres psql -U rag -d rag -c "\dt"
+    </code></pre>
+    <p>La table <code>document_chunks</code> doit apparaître (créée par <code>infra/init.sql</code>).</p>
+  </section>
+</section>
+
+<!-- TACHE 1.3 -->
+<section>
+  <h3 class="task-title">Tâche 1.3 : Installer pre-commit</h3>
+  <pre><code class="language-bash" data-trim>
+pip install pre-commit     # ou uv tool install pre-commit
+pre-commit install
+pre-commit run --all-files # tout doit passer
+  </code></pre>
+</section>
+
+<!-- TACHE 1.4 -->
+<section>
+  <h3 class="task-title">Tâche 1.4 : Explorer le justfile racine</h3>
+  <pre><code class="language-bash" data-trim>
+just --list                # voir toutes les recettes disponibles
+  </code></pre>
+  <p>Comprendre les recettes <code>infra-up</code>, <code>infra-down</code>, <code>load</code>, <code>embed</code>, <code>serve</code>, <code>query</code>.</p>
+</section>
+
+<!-- ============================================ -->
+<!-- EPIC 2 — BIBLIOTHEQUES PARTAGEES              -->
+<!-- ============================================ -->
+<section>
+  <h2>Epic 2 — Bibliothèques partagées</h2>
+  <p>(fournies, ~1h30)</p>
+  <p>Les 3 bibliothèques sont <strong>fournies complètes</strong>. L'objectif est de les comprendre car elles seront utilisées dans les packages suivants.</p>
+</section>
+
+<!-- TACHE 2.1 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 2.1 : Explorer lib-schemas</h3>
+    <p><strong>Fichier</strong> : <code>python/lib-schemas/lib_schemas/schemas.py</code></p>
+    <p>Modèles Pydantic partagés entre les packages :</p>
+    <table>
+      <thead>
+        <tr><th>Classe</th><th>Usage</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>ChunkInput</code></td><td>Chunk de texte (document_name, chunk_index, content, metadata)</td></tr>
+        <tr><td><code>ChunkWithEmbedding</code></td><td>ChunkInput + vecteur embedding (list[float])</td></tr>
+        <tr><td><code>SearchRequest</code></td><td>Requête API (query, top_k, similarity_threshold)</td></tr>
+        <tr><td><code>SearchResult</code></td><td>Résultat de recherche (chunk_id, document_name, content, similarity_score)</td></tr>
+        <tr><td><code>SearchResponse</code></td><td>Réponse API (results, total_results, timings)</td></tr>
+        <tr><td><code>StatsResponse</code></td><td>Statistiques documents (total_documents, total_chunks, embedding_dimension, model_name)</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 2.1 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+cd python/lib-schemas && just test
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 2.2 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 2.2 : Explorer lib-embedding</h3>
+    <p><strong>Fichier</strong> : <code>python/lib-embedding/lib_embedding/embedding.py</code></p>
+    <ul>
+      <li><code>EmbeddingClient(model_name)</code> — charge le modèle sentence-transformers</li>
+      <li><code>encode(texts: list[str]) -&gt; list[list[float]]</code> — encode une liste de textes en vecteurs 384-dim</li>
+      <li><code>dimension</code> — propriété retournant la dimension du modèle</li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 2.2 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+cd python/lib-embedding && just test
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 2.3 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 2.3 : Explorer lib-orm</h3>
+    <p><strong>Fichiers</strong> :</p>
+    <ul>
+      <li><code>python/lib-orm/lib_orm/db.py</code> — <code>get_async_engine()</code>, <code>get_async_session()</code></li>
+      <li><code>python/lib-orm/lib_orm/models.py</code> — ORM <code>DocumentChunk</code> (SQLAlchemy + pgvector)</li>
+    </ul>
+    <p>La table <code>document_chunks</code> correspond au schéma dans <code>infra/init.sql</code> :</p>
+    <ul>
+      <li><code>id</code> (UUID), <code>document_name</code>, <code>chunk_index</code>, <code>content</code>, <code>metadata</code> (JSONB), <code>embedding</code> (vector(384))</li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 2.3 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+cd python/lib-orm && just test
+    </code></pre>
+  </section>
+</section>
+
+<!-- ============================================ -->
+<!-- EPIC 3 — DOCUMENT LOADER                      -->
+<!-- ============================================ -->
+<section>
+  <h2>Epic 3 — Document Loader</h2>
+  <p>(hands-on, ~2h)</p>
+  <p>C'est le premier package que les étudiants <strong>implémentent eux-mêmes</strong>.</p>
+</section>
+
+<!-- TACHE 3.1 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 3.1 : Comprendre la structure du package</h3>
+    <pre class="tree-block"><code data-trim>
+python/rag-loader/
+├── rag_loader/
+│   ├── __init__.py       # fourni
+│   ├── main.py           # fourni (projen, ne pas modifier)
+│   ├── task_inputs.py    # fourni
+│   ├── app.py            # À IMPLÉMENTER
+│   ├── reader.py         # À IMPLÉMENTER
+│   └── chunker.py        # À IMPLÉMENTER
+├── tests/                # fournis
+├── pyproject.toml        # fourni
+├── justfile              # fourni
+└── uv.lock               # fourni
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.1 : Installer et tester</h3>
+    <p>Installer les dépendances :</p>
+    <pre><code class="language-bash" data-trim>
+cd python/rag-loader && just install-dev
+    </code></pre>
+    <p>Exécuter les tests pour voir ce qui échoue :</p>
+    <pre><code class="language-bash" data-trim>
+just test   # tout doit être rouge sauf test_init et test_task_inputs
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 3.2 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 3.2 : Implémenter le lecteur de documents</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-loader/rag_loader/reader.py</code></p>
+    <p><strong>Fonction à implémenter</strong> :</p>
+    <pre><code class="language-python" data-trim>
+SUPPORTED_EXTENSIONS = {".txt", ".md"}
+
+def read_documents(input_dir: str) -> list[dict[str, object]]:
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.2 : Comportement attendu</h3>
+    <ol>
+      <li>Vérifier que <code>input_dir</code> existe et est un dossier (sinon <code>FileNotFoundError</code> / <code>NotADirectoryError</code>)</li>
+      <li>Lister les fichiers <code>.md</code> et <code>.txt</code> uniquement (non récursif)</li>
+      <li>Trier les fichiers par nom avant traitement</li>
+      <li>Lire chaque fichier en UTF-8 (utiliser <code>encoding="utf-8-sig"</code> pour gérer le BOM)</li>
+      <li>Retourner une liste de dicts avec les clés : <code>document_name</code>, <code>content</code>, <code>metadata</code></li>
+      <li><code>metadata</code> contient <code>file_size</code> (int) et <code>extension</code> (str)</li>
+    </ol>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.2 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+just test -- -k test_reader   # 8 tests doivent passer
+    </code></pre>
+  </section>
+  <section>
+    <h3><span class="hint-label">Indice 1 : structure de base</span></h3>
+    <pre><code class="language-python" data-trim>
+from pathlib import Path
+
+def read_documents(input_dir: str) -> list[dict[str, object]]:
+    path = Path(input_dir)
+    if not path.exists():
+        raise FileNotFoundError(...)
+    if not path.is_dir():
+        raise NotADirectoryError(...)
+
+    documents = []
+    for file_path in sorted(path.iterdir()):
+        if file_path.suffix in SUPPORTED_EXTENSIONS:
+            # lire le fichier et construire le dict
+            ...
+    return documents
+    </code></pre>
+  </section>
+  <section>
+    <h3><span class="hint-label">Indice 2 : construction du dict retourné</span></h3>
+    <pre><code class="language-python" data-trim>
+content = file_path.read_text(encoding="utf-8-sig")
+documents.append({
+    "document_name": file_path.name,
+    "content": content,
+    "metadata": {
+        "file_size": file_path.stat().st_size,
+        "extension": file_path.suffix,
+    },
+})
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 3.3 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 3.3 : Implémenter le chunker</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-loader/rag_loader/chunker.py</code></p>
+    <p>C'est l'algorithme le plus intéressant de la session : un <strong>recursive character splitter</strong> (~50 lignes).</p>
+    <p><strong>Fonctions à implémenter</strong> :</p>
+    <pre><code class="language-python" data-trim>
+SEPARATORS = ["\n\n", "\n", ". ", " ", ""]
+
+def chunk_text(text: str, chunk_size: int = 512,
+               chunk_overlap: int = 64) -> list[str]:
+    ...
+
+def _split_recursive(text: str, chunk_size: int,
+                     sep_idx: int) -> list[str]:
+    ...
+
+def _merge_with_overlap(segments: list[str], chunk_size: int,
+                        chunk_overlap: int) -> list[str]:
+    ...
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.3 : Algorithme de chunk_text</h3>
+    <ol>
+      <li>Lever <code>ValueError</code> si <code>chunk_overlap &gt;= chunk_size</code></li>
+      <li>Retourner <code>[]</code> si le texte est vide ou ne contient que des espaces</li>
+      <li>Appeler <code>_split_recursive(text, chunk_size, 0)</code> pour obtenir des segments</li>
+      <li>Appeler <code>_merge_with_overlap(segments, chunk_size, chunk_overlap)</code> pour fusionner avec recouvrement</li>
+    </ol>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.3 : Algorithme de _split_recursive</h3>
+    <ol>
+      <li>Si <code>len(text) &lt;= chunk_size</code> : retourner <code>[text]</code></li>
+      <li>Si <code>sep_idx &gt;= len(SEPARATORS)</code> : retourner <code>[text]</code> (dernier recours)</li>
+      <li>Séparer le texte avec <code>SEPARATORS[sep_idx]</code></li>
+      <li>Pour le séparateur <code>""</code> : découper caractère par caractère (<code>text[i:i+chunk_size]</code>)</li>
+      <li>Si le split ne produit qu'un seul morceau : essayer le séparateur suivant</li>
+      <li>Pour <code>". "</code> : rattacher le <code>.</code> à la fin de chaque segment</li>
+      <li>Filtrer les segments vides, et récurser sur les segments trop longs</li>
+    </ol>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.3 : Algorithme de _merge_with_overlap</h3>
+    <ol>
+      <li>Fusionner les segments tant que <code>len(merged) + 1 + len(next) &lt;= chunk_size</code></li>
+      <li>Quand la limite est atteinte : sauvegarder le chunk courant, calculer le recouvrement depuis la fin</li>
+      <li>Le recouvrement = derniers <code>chunk_overlap</code> caractères du chunk qui vient d'être sauvegardé</li>
+    </ol>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.3 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+just test -- -k test_chunker   # 13 tests doivent passer
+    </code></pre>
+  </section>
+  <section>
+    <h3><span class="hint-label">Indice 1 : _split_recursive cas de base</span></h3>
+    <pre><code class="language-python" data-trim>
+def _split_recursive(text: str, chunk_size: int,
+                     sep_idx: int) -> list[str]:
+    if len(text) <= chunk_size:
+        return [text]
+    if sep_idx >= len(SEPARATORS):
+        return [text]
+
+    sep = SEPARATORS[sep_idx]
+    if sep == "":
+        return [text[i:i + chunk_size]
+                for i in range(0, len(text), chunk_size)]
+    ...
+    </code></pre>
+  </section>
+  <section>
+    <h3><span class="hint-label">Indice 2 : _merge_with_overlap boucle principale</span></h3>
+    <pre><code class="language-python" data-trim>
+def _merge_with_overlap(segments, chunk_size, chunk_overlap):
+    if not segments:
+        return []
+    chunks = []
+    current = segments[0]
+    for seg in segments[1:]:
+        candidate = current + " " + seg
+        if len(candidate) <= chunk_size:
+            current = candidate
+        else:
+            chunks.append(current)
+            overlap_text = current[-chunk_overlap:] \
+                if chunk_overlap > 0 else ""
+            current = (overlap_text + " " + seg).strip() \
+                if overlap_text else seg
+    chunks.append(current)
+    return chunks
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 3.4 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 3.4 : Implémenter App.run()</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-loader/rag_loader/app.py</code></p>
+    <p><strong>Méthode à implémenter</strong> : <code>App.run(self) -&gt; None</code></p>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.4 : Comportement attendu</h3>
+    <ol>
+      <li>Afficher la configuration de <code>task_inputs</code> (input_dir, output_dir, chunk_size, chunk_overlap)</li>
+      <li>Appeler <code>read_documents(task_inputs.input_dir)</code></li>
+      <li>Pour chaque document : appeler <code>chunk_text()</code> et créer des objets <code>ChunkInput</code> (de <code>lib_schemas</code>)</li>
+      <li>Créer le dossier de sortie (<code>output_dir</code>) s'il n'existe pas</li>
+      <li>Écrire la liste de chunks en JSON dans <code>output_dir/chunks.json</code></li>
+      <li>Afficher des messages de progression ("Read N documents", "Generated N chunks")</li>
+    </ol>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.4 : Imports nécessaires</h3>
+    <pre><code class="language-python" data-trim>
+import json
+from pathlib import Path
+from lib_schemas.schemas import ChunkInput
+from rag_loader.chunker import chunk_text
+from rag_loader.reader import read_documents
+from rag_loader.task_inputs import task_inputs
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.4 : Vérification</h3>
+    <pre><code class="language-bash" data-trim>
+just test -- -k test_app     # 2 tests doivent passer
+just test                     # TOUS les tests doivent passer
+just check-all                # ruff + mypy clean
+    </code></pre>
+  </section>
+</section>
+
+<!-- TACHE 3.5 -->
+<section>
+  <section>
+    <h3 class="task-title">Tâche 3.5 : Exécuter le loader</h3>
+    <pre><code class="language-bash" data-trim>
+just run   # depuis python/rag-loader/
+# ou depuis la racine :
+just load
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">Tâche 3.5 : Vérifier le résultat</h3>
+    <p>Vérifier le fichier <code>data/chunks/chunks.json</code> :</p>
+    <pre><code class="language-bash" data-trim>
+python -c "import json; chunks = json.load(open('data/chunks/chunks.json')); print(f'{len(chunks)} chunks')"
+    </code></pre>
+  </section>
+</section>
+
+<!-- ============================================ -->
+<!-- RECAPITULATIF                                 -->
+<!-- ============================================ -->
+<section>
+  <h2>Récapitulatif Session 1</h2>
+  <p>À la fin de cette session, vous avez :</p>
+  <ul>
+    <li>PostgreSQL + pgvector fonctionnel (<code>docker compose ps</code>)</li>
+    <li>Pre-commit installé et fonctionnel</li>
+    <li>Compris les 3 bibliothèques partagées (lib-schemas, lib-embedding, lib-orm)</li>
+    <li>Implémenté <code>reader.py</code> — lecture de fichiers .md/.txt</li>
+    <li>Implémenté <code>chunker.py</code> — recursive character splitter</li>
+    <li>Implémenté <code>app.py</code> — orchestration du loader</li>
+    <li><code>just load</code> produit <code>data/chunks/chunks.json</code></li>
+    <li><code>just test</code> passe dans <code>python/rag-loader/</code></li>
+    <li><code>just check-all</code> passe dans <code>python/rag-loader/</code></li>
+  </ul>
+</section>
+
+</div><!-- .slides -->
+</div><!-- .reveal -->
+
+<script src="https://unpkg.com/reveal.js@5/dist/reveal.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/highlight/highlight.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/markdown/markdown.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/notes/notes.js"></script>
+<script>
+  Reveal.initialize({
+    slideNumber: true,
+    hash: true,
+    width: 1280,
+    height: 720,
+    plugins: [RevealHighlight, RevealMarkdown, RevealNotes]
+  });
+</script>
+</body>
+</html>

--- a/course/slides/session-2-slides.html
+++ b/course/slides/session-2-slides.html
@@ -1,0 +1,635 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session 2 — Embedding et API</title>
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reset.css">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reveal.css">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/theme/moon.css">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/plugin/highlight/monokai.css">
+  <style>
+    .reveal pre code {
+      max-height: 500px;
+      font-size: 0.45em;
+      line-height: 1.4;
+    }
+    .reveal table {
+      font-size: 0.6em;
+    }
+    .reveal table th,
+    .reveal table td {
+      border: 1px solid #555;
+      padding: 0.3em 0.6em;
+    }
+    .reveal table thead th {
+      border-bottom: 2px solid #888;
+    }
+    .reveal li {
+      font-size: 0.75em;
+    }
+    .task-title {
+      color: #4fc3f7 !important;
+    }
+    .reveal h2 {
+      font-size: 1.4em;
+    }
+    .reveal h3 {
+      font-size: 1.1em;
+    }
+    .reveal p {
+      font-size: 0.75em;
+    }
+    .reveal .small {
+      font-size: 0.6em;
+    }
+    .hint-title {
+      color: #ffd54f;
+      font-size: 0.9em;
+    }
+    .reveal blockquote {
+      font-size: 0.75em;
+      width: 90%;
+    }
+    .checklist li {
+      list-style: none;
+      font-size: 0.65em;
+    }
+    .checklist li::before {
+      content: "\2610\0020";
+    }
+  </style>
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+
+      <!-- ===== TITLE SLIDE ===== -->
+      <section>
+        <h1 style="font-size:1.6em;">Session 2 — Embedding et API</h1>
+        <p style="font-size:0.85em;">Embedder et Retriever : du texte aux vecteurs, des vecteurs à l'API</p>
+      </section>
+
+      <!-- ===== PLANNING ===== -->
+      <section>
+        <h2>Planning</h2>
+        <table>
+          <thead>
+            <tr><th>Horaire</th><th>Activit&eacute;</th><th>Type</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>0:00-0:30</td><td>R&eacute;capitulatif Session 1, crash course pgvector</td><td>Cours</td></tr>
+            <tr><td>0:30-2:15</td><td>Epic 4 : impl&eacute;mentation de rag-embedder</td><td>Hands-on</td></tr>
+            <tr><td>2:15-2:30</td><td>Pause</td><td></td></tr>
+            <tr><td>2:30-3:00</td><td>D&eacute;mo : FastAPI patterns, injection de d&eacute;pendances</td><td>Cours</td></tr>
+            <tr><td>3:00-5:00</td><td>Epic 5 : impl&eacute;mentation de rag-retriever</td><td>Hands-on</td></tr>
+            <tr><td>5:00-5:15</td><td>Pause</td><td></td></tr>
+            <tr><td>5:15-6:00</td><td>Wire uvicorn, <code>just serve</code> + <code>just query</code></td><td>Hands-on</td></tr>
+            <tr><td>6:00-6:30</td><td>Pipeline locale compl&egrave;te : <code>just pipeline &amp;&amp; just serve</code></td><td>D&eacute;mo</td></tr>
+            <tr><td>6:30-7:00</td><td><code>just test-all</code> + <code>just check-all</code>, correction</td><td>Hands-on</td></tr>
+          </tbody>
+        </table>
+        <p><strong>Livrable</strong> : le syst&egrave;me RAG fonctionne en local. <code>just query "qu'est-ce que le MLOps ?"</code> retourne des r&eacute;sultats class&eacute;s par similarit&eacute;.</p>
+      </section>
+
+      <!-- ===== CRASH COURSE PGVECTOR ===== -->
+      <section>
+        <h2>Crash course pgvector</h2>
+        <p><em>Cours, ~15 min</em></p>
+        <p>Concepts cl&eacute;s &agrave; comprendre avant de coder :</p>
+        <ul>
+          <li><strong>Embedding</strong> : repr&eacute;sentation d'un texte sous forme de vecteur de 384 nombres flottants</li>
+          <li><strong>pgvector</strong> : extension PostgreSQL qui ajoute le type <code>vector(384)</code> et l'op&eacute;rateur <code>&lt;=&gt;</code> (distance cosinus)</li>
+          <li><strong>Similarit&eacute; cosinus</strong> : <code>1 - distance</code>. Plus le score est proche de 1, plus les textes sont similaires</li>
+          <li><strong>IVFFlat</strong> : index approximatif pour acc&eacute;l&eacute;rer les recherches (pas exact, mais rapide)</li>
+          <li><strong>Upsert</strong> : <code>INSERT ... ON CONFLICT DO UPDATE</code> — &eacute;vite les doublons</li>
+        </ul>
+      </section>
+
+      <!-- ===== PGVECTOR SCHEMA ===== -->
+      <section>
+        <h2>Crash course pgvector — Sch&eacute;ma</h2>
+        <p>Sch&eacute;ma de la table (voir <code>infra/init.sql</code>) :</p>
+        <pre><code class="language-sql" data-trim>
+CREATE TABLE document_chunks (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_name VARCHAR(512) NOT NULL,
+    chunk_index   INTEGER NOT NULL,
+    content       TEXT NOT NULL,
+    metadata      JSONB NOT NULL DEFAULT '{}',
+    embedding     vector(384) NOT NULL,
+    created_at    TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    CONSTRAINT uq_document_chunk UNIQUE (document_name, chunk_index)
+);
+        </code></pre>
+      </section>
+
+      <!-- ===== EPIC 4 HEADER ===== -->
+      <section>
+        <h2>Epic 4 — Embedder</h2>
+        <p><em>Hands-on, ~1h45</em></p>
+      </section>
+
+      <!-- ===== TACHE 4.1 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 4.1 : Comprendre la structure du package</h3>
+          <pre><code class="language-text" data-trim>
+python/rag-embedder/
+├── rag_embedder/
+│   ├── __init__.py       # fourni
+│   ├── main.py           # fourni (projen)
+│   ├── task_inputs.py    # fourni
+│   ├── app.py            # À IMPLÉMENTER
+│   └── writer.py         # À IMPLÉMENTER
+├── tests/                # fournis
+├── pyproject.toml        # fourni
+├── justfile              # fourni
+└── uv.lock               # fourni
+          </code></pre>
+          <pre><code class="language-bash" data-trim>
+cd python/rag-embedder && just install-dev
+just test   # voir ce qui échoue
+          </code></pre>
+          <p><strong>TaskInputs fournis</strong> : <code>input_dir</code> (data/chunks), <code>output_dir</code> (data/embeddings), <code>db_url</code>, <code>embedding_model</code> (all-MiniLM-L6-v2), <code>batch_size</code> (32).</p>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 4.2 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 4.2 : Impl&eacute;menter le writer (batch upsert)</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-embedder/rag_embedder/writer.py</code></p>
+          <p><strong>Fonction &agrave; impl&eacute;menter</strong> :</p>
+          <pre><code class="language-python" data-trim>
+async def write_chunks(session: AsyncSession, chunks: list[ChunkWithEmbedding]) -> int:
+          </code></pre>
+          <p><strong>Comportement attendu</strong> :</p>
+          <ol>
+            <li>Retourner <code>0</code> si la liste est vide</li>
+            <li>Pour chaque chunk, chercher un <code>DocumentChunk</code> existant par <code>(document_name, chunk_index)</code></li>
+            <li>Si trouv&eacute; : mettre &agrave; jour <code>content</code>, <code>metadata_</code> et <code>embedding</code></li>
+            <li>Si non trouv&eacute; : cr&eacute;er un nouveau <code>DocumentChunk</code> et l'ajouter &agrave; la session</li>
+            <li>Appeler <code>session.flush()</code> &agrave; la fin</li>
+            <li>Retourner le nombre total de lignes affect&eacute;es</li>
+          </ol>
+        </section>
+
+        <!-- 4.2 suite : imports + vérification -->
+        <section>
+          <h3 class="task-title">T&acirc;che 4.2 — Imports &amp; v&eacute;rification</h3>
+          <p><strong>Imports n&eacute;cessaires</strong> :</p>
+          <pre><code class="language-python" data-trim>
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from lib_orm.models import DocumentChunk
+from lib_schemas.schemas import ChunkWithEmbedding
+          </code></pre>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_writer   # 5 tests doivent passer
+          </code></pre>
+        </section>
+
+        <!-- 4.2 Indice 1 -->
+        <section>
+          <h3 class="hint-title">Indice 1 : recherche d'un chunk existant</h3>
+          <pre><code class="language-python" data-trim>
+stmt = select(DocumentChunk).where(
+    DocumentChunk.document_name == chunk.document_name,
+    DocumentChunk.chunk_index == chunk.chunk_index,
+)
+result = await session.execute(stmt)
+existing = result.scalar_one_or_none()
+          </code></pre>
+        </section>
+
+        <!-- 4.2 Indice 2 -->
+        <section>
+          <h3 class="hint-title">Indice 2 : cr&eacute;ation d'un nouveau DocumentChunk</h3>
+          <pre><code class="language-python" data-trim>
+row = DocumentChunk(
+    document_name=chunk.document_name,
+    chunk_index=chunk.chunk_index,
+    content=chunk.content,
+    metadata_=chunk.metadata,
+    embedding=chunk.embedding,
+)
+session.add(row)
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 4.3 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 4.3 : Impl&eacute;menter App.run()</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-embedder/rag_embedder/app.py</code></p>
+          <p><strong>M&eacute;thode &agrave; impl&eacute;menter</strong> : <code>App.run(self) -&gt; None</code></p>
+          <p><strong>Comportement attendu</strong> :</p>
+          <ol>
+            <li>Afficher la configuration de <code>task_inputs</code></li>
+            <li>Charger les chunks depuis les fichiers JSON dans <code>input_dir</code> (<code>Path.glob("*.json")</code>)</li>
+            <li>Valider les chunks comme liste de <code>ChunkInput</code></li>
+            <li>Cr&eacute;er un <code>EmbeddingClient(task_inputs.embedding_model)</code> et encoder les textes</li>
+            <li>Construire des objets <code>ChunkWithEmbedding</code> avec les embeddings</li>
+            <li>Sauvegarder en JSON dans <code>output_dir/embeddings.json</code></li>
+            <li>&Eacute;crire dans la base de donn&eacute;es via <code>_write_to_db()</code> (m&eacute;thode statique async, appel&eacute;e via <code>asyncio.run()</code>)</li>
+          </ol>
+        </section>
+
+        <!-- 4.3 suite : _write_to_db -->
+        <section>
+          <h3 class="task-title">T&acirc;che 4.3 — M&eacute;thode statique <code>_write_to_db</code></h3>
+          <p><strong>M&eacute;thode statique <code>_write_to_db</code></strong> :</p>
+          <ol>
+            <li>Obtenir une session async via <code>get_async_session(task_inputs.db_url)</code></li>
+            <li>Appeler <code>write_chunks(session, results)</code></li>
+            <li>G&eacute;rer les erreurs de connexion gracieusement (print, pas crash)</li>
+          </ol>
+        </section>
+
+        <!-- 4.3 suite : imports + vérification -->
+        <section>
+          <h3 class="task-title">T&acirc;che 4.3 — Imports &amp; v&eacute;rification</h3>
+          <p><strong>Imports n&eacute;cessaires</strong> :</p>
+          <pre><code class="language-python" data-trim>
+import asyncio
+import json
+from pathlib import Path
+from lib_embedding.embedding import EmbeddingClient
+from lib_orm.db import get_async_session
+from lib_schemas.schemas import ChunkInput, ChunkWithEmbedding
+from rag_embedder.task_inputs import task_inputs
+from rag_embedder.writer import write_chunks
+          </code></pre>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_app   # 3 tests doivent passer
+just test                   # TOUS les tests
+just check-all              # ruff + mypy clean
+          </code></pre>
+        </section>
+
+        <!-- 4.3 Indice -->
+        <section>
+          <h3 class="hint-title">Indice : chargement des chunks JSON</h3>
+          <pre><code class="language-python" data-trim>
+all_chunks: list[ChunkInput] = []
+for json_file in Path(task_inputs.input_dir).glob("*.json"):
+    data = json.loads(json_file.read_text())
+    all_chunks.extend([ChunkInput(**item) for item in data])
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 4.4 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 4.4 : Ex&eacute;cuter l'embedder</h3>
+          <p>Assurez-vous que PostgreSQL tourne et que les chunks existent :</p>
+          <pre><code class="language-bash" data-trim>
+# Depuis la racine
+just load     # produit data/chunks/chunks.json
+just embed    # lit les chunks, génère les embeddings, écrit dans pgvector
+          </code></pre>
+          <p>V&eacute;rifier dans la base :</p>
+          <pre><code class="language-bash" data-trim>
+docker exec -it rag-postgres psql -U rag -d rag \
+  -c "SELECT count(*) FROM document_chunks;"
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== EPIC 5 HEADER ===== -->
+      <section>
+        <h2>Epic 5 — Retriever API</h2>
+        <p><em>Hands-on, ~2h30</em></p>
+      </section>
+
+      <!-- ===== TACHE 5.1 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.1 : Comprendre la structure du package</h3>
+          <pre><code class="language-text" data-trim>
+python/rag-retriever/
+├── rag_retriever/
+│   ├── __init__.py          # fourni
+│   ├── main.py              # fourni (projen)
+│   ├── task_inputs.py       # fourni
+│   ├── app.py               # À IMPLÉMENTER
+│   ├── api.py               # À IMPLÉMENTER
+│   ├── dependencies.py      # À IMPLÉMENTER
+│   └── routes/
+│       ├── __init__.py      # fourni
+│       ├── health.py        # À IMPLÉMENTER
+│       ├── search.py        # À IMPLÉMENTER
+│       └── documents.py     # À IMPLÉMENTER
+├── tests/                   # fournis
+├── pyproject.toml           # fourni
+├── justfile                 # fourni
+└── uv.lock                  # fourni
+          </code></pre>
+          <pre><code class="language-bash" data-trim>
+cd python/rag-retriever && just install-dev
+just test   # voir ce qui échoue
+          </code></pre>
+          <p><strong>TaskInputs fournis</strong> : <code>host</code> (0.0.0.0), <code>port</code> (8000), <code>db_url</code>, <code>embedding_model</code>, <code>top_k</code> (5).</p>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.2 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.2 : Impl&eacute;menter les d&eacute;pendances (DI)</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/dependencies.py</code></p>
+          <p>Ce module g&egrave;re les ressources partag&eacute;es (engine DB + client embedding) comme singletons.</p>
+          <p><strong>Variables globales</strong> :</p>
+          <pre><code class="language-python" data-trim>
+_engine: AsyncEngine | None = None
+_embedding_client: EmbeddingClient | None = None
+          </code></pre>
+        </section>
+
+        <!-- 5.2 suite : fonctions -->
+        <section>
+          <h3 class="task-title">T&acirc;che 5.2 — Fonctions &agrave; impl&eacute;menter</h3>
+          <table>
+            <thead>
+              <tr><th>Fonction</th><th>R&ocirc;le</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>async init_dependencies()</code></td><td>Initialise <code>_engine</code> et <code>_embedding_client</code></td></tr>
+              <tr><td><code>async shutdown_dependencies()</code></td><td>Dispose <code>_engine</code>, remet les globals &agrave; <code>None</code></td></tr>
+              <tr><td><code>async get_db_session()</code></td><td>G&eacute;n&eacute;rateur async qui yield une <code>AsyncSession</code> (commit/rollback)</td></tr>
+              <tr><td><code>get_embedding_client()</code></td><td>Retourne le client, <code>RuntimeError</code> si non initialis&eacute;</td></tr>
+              <tr><td><code>async check_db_health()</code></td><td>Ex&eacute;cute <code>SELECT 1</code>, retourne <code>bool</code></td></tr>
+              <tr><td><code>check_model_health()</code></td><td>Retourne <code>True</code> si le client existe</td></tr>
+            </tbody>
+          </table>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_dependencies   # 7 tests doivent passer
+          </code></pre>
+        </section>
+
+        <!-- 5.2 Indice 1 -->
+        <section>
+          <h3 class="hint-title">Indice : init_dependencies</h3>
+          <pre><code class="language-python" data-trim>
+async def init_dependencies() -> None:
+    global _engine, _embedding_client
+    _engine = get_async_engine(task_inputs.db_url)
+    _embedding_client = EmbeddingClient(task_inputs.embedding_model)
+          </code></pre>
+        </section>
+
+        <!-- 5.2 Indice 2 -->
+        <section>
+          <h3 class="hint-title">Indice : get_db_session (g&eacute;n&eacute;rateur async)</h3>
+          <pre><code class="language-python" data-trim>
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
+    if _engine is None:
+        raise RuntimeError("Database engine not initialized")
+    async with AsyncSession(_engine) as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.3 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.3 : Impl&eacute;menter les endpoints de sant&eacute;</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/routes/health.py</code></p>
+          <table>
+            <thead>
+              <tr><th>M&eacute;thode</th><th>Route</th><th>R&eacute;ponse</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>GET</td><td><code>/health</code></td><td><code>{"status": "ok"}</code> — toujours 200</td></tr>
+              <tr><td>GET</td><td><code>/ready</code></td><td>V&eacute;rifie DB + mod&egrave;le. 200 si tout OK, 503 sinon</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- 5.3 suite : réponses /ready -->
+        <section>
+          <h3 class="task-title">T&acirc;che 5.3 — R&eacute;ponses <code>/ready</code></h3>
+          <p><code>/ready</code> retourne :</p>
+          <pre><code class="language-json" data-trim>
+{"status": "ready", "db": true, "model": true}
+          </code></pre>
+          <p>ou (avec status code 503) :</p>
+          <pre><code class="language-json" data-trim>
+{"status": "not_ready", "db": false, "model": true}
+          </code></pre>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_health   # 4 tests doivent passer
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.4 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.4 : Impl&eacute;menter POST /search</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/routes/search.py</code></p>
+          <p>C'est l'endpoint principal du syst&egrave;me RAG.</p>
+          <p><strong>Signature</strong> :</p>
+          <pre><code class="language-python" data-trim>
+@router.post("/search", response_model=SearchResponse)
+async def search(
+    body: SearchRequest,
+    session: AsyncSession = Depends(get_db_session),
+    client: EmbeddingClient = Depends(get_embedding_client),
+) -> SearchResponse:
+          </code></pre>
+        </section>
+
+        <!-- 5.4 suite : algorithme -->
+        <section>
+          <h3 class="task-title">T&acirc;che 5.4 — Algorithme</h3>
+          <ol>
+            <li>Encoder la query avec <code>client.encode([body.query])</code> &rarr; vecteur 384-dim</li>
+            <li>Mesurer le temps d'embedding (en ms)</li>
+            <li>Construire la requ&ecirc;te SQL pgvector :
+              <ul>
+                <li><code>1 - (embedding &lt;=&gt; query_embedding)</code> comme score de similarit&eacute;</li>
+                <li>Filtrer par <code>similarity &gt;= body.similarity_threshold</code></li>
+                <li>Trier par similarit&eacute; d&eacute;croissante</li>
+                <li>Limiter &agrave; <code>body.top_k</code></li>
+              </ul>
+            </li>
+            <li>Mesurer le temps de recherche (en ms)</li>
+            <li>Construire les <code>SearchResult</code> et retourner <code>SearchResponse</code></li>
+          </ol>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_search   # 5 tests doivent passer
+          </code></pre>
+        </section>
+
+        <!-- 5.4 Indice -->
+        <section>
+          <h3 class="hint-title">Indice : requ&ecirc;te pgvector avec SQLAlchemy</h3>
+          <pre><code class="language-python" data-trim>
+import time
+from sqlalchemy import select, literal_column
+
+query_vector = client.encode([body.query])[0]
+similarity = (
+    literal_column("1") - DocumentChunk.embedding.cosine_distance(query_vector)
+).label("similarity_score")
+
+stmt = (
+    select(DocumentChunk, similarity)
+    .where(similarity >= body.similarity_threshold)
+    .order_by(similarity.desc())
+    .limit(body.top_k)
+)
+
+start = time.perf_counter()
+result = await session.execute(stmt)
+rows = result.all()
+search_ms = (time.perf_counter() - start) * 1000
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.5 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.5 : Impl&eacute;menter GET /documents/stats</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/routes/documents.py</code></p>
+          <p><strong>Endpoint</strong> : <code>GET /documents/stats</code></p>
+          <p>Retourne un <code>StatsResponse</code> :</p>
+          <pre><code class="language-json" data-trim>
+{
+  "total_documents": 5,
+  "total_chunks": 42,
+  "embedding_dimension": 384,
+  "model_name": "all-MiniLM-L6-v2"
+}
+          </code></pre>
+          <p><strong>SQL</strong> : <code>SELECT count(DISTINCT document_name), count(*) FROM document_chunks</code></p>
+          <p><strong>V&eacute;rification</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test -- -k test_documents   # 2 tests doivent passer
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.6 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.6 : Impl&eacute;menter l'API factory</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/api.py</code></p>
+          <p><strong>Fonctions</strong> :</p>
+          <ol>
+            <li><code>lifespan(app)</code> — context manager async qui appelle <code>init_dependencies()</code> au d&eacute;marrage et <code>shutdown_dependencies()</code> &agrave; l'arr&ecirc;t</li>
+            <li><code>create_app()</code> — cr&eacute;e l'app FastAPI avec titre, description, version, lifespan, et enregistre les 3 routers</li>
+          </ol>
+          <pre><code class="language-python" data-trim>
+from rag_retriever.routes.health import router as health_router
+from rag_retriever.routes.search import router as search_router
+from rag_retriever.routes.documents import router as documents_router
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.7 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.7 : Impl&eacute;menter App.run()</h3>
+          <p><strong>Fichier</strong> : <code>python/rag-retriever/rag_retriever/app.py</code></p>
+          <p>D&eacute;marre uvicorn en mode factory :</p>
+          <pre><code class="language-python" data-trim>
+uvicorn.run(
+    "rag_retriever.api:create_app",
+    host=task_inputs.host,
+    port=task_inputs.port,
+    factory=True,
+)
+          </code></pre>
+          <p><strong>V&eacute;rification finale</strong> :</p>
+          <pre><code class="language-bash" data-trim>
+just test                     # TOUS les tests
+just check-all                # ruff + mypy clean
+          </code></pre>
+        </section>
+      </section>
+
+      <!-- ===== TACHE 5.8 ===== -->
+      <section>
+        <section>
+          <h3 class="task-title">T&acirc;che 5.8 : Tester le syst&egrave;me complet</h3>
+          <pre><code class="language-bash" data-trim>
+# Depuis la racine
+just pipeline                 # load + embed
+just serve                    # démarre l'API sur http://localhost:8000
+
+# Dans un autre terminal
+just query "what is MLOps?"
+# ou avec curl :
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "what is MLOps?", "top_k": 5}'
+          </code></pre>
+        </section>
+
+        <!-- 5.8 suite : autres endpoints -->
+        <section>
+          <h3 class="task-title">T&acirc;che 5.8 — Autres endpoints &agrave; tester</h3>
+          <ul>
+            <li><code>http://localhost:8000/health</code></li>
+            <li><code>http://localhost:8000/ready</code></li>
+            <li><code>http://localhost:8000/documents/stats</code></li>
+            <li><code>http://localhost:8000/docs</code> (Swagger UI auto-g&eacute;n&eacute;r&eacute; par FastAPI)</li>
+          </ul>
+        </section>
+      </section>
+
+      <!-- ===== RECAP ===== -->
+      <section>
+        <h2>R&eacute;capitulatif Session 2</h2>
+        <p>&Agrave; la fin de cette session, vous avez :</p>
+        <ul class="checklist">
+          <li>Impl&eacute;ment&eacute; <code>writer.py</code> — batch upsert dans pgvector</li>
+          <li>Impl&eacute;ment&eacute; <code>app.py</code> du rag-embedder — chargement, embedding, sauvegarde</li>
+          <li><code>just embed</code> ins&egrave;re des vecteurs dans PostgreSQL</li>
+          <li>Impl&eacute;ment&eacute; <code>dependencies.py</code> — injection de d&eacute;pendances FastAPI</li>
+          <li>Impl&eacute;ment&eacute; <code>routes/health.py</code> — endpoints /health et /ready</li>
+          <li>Impl&eacute;ment&eacute; <code>routes/search.py</code> — recherche s&eacute;mantique avec pgvector</li>
+          <li>Impl&eacute;ment&eacute; <code>routes/documents.py</code> — statistiques</li>
+          <li>Impl&eacute;ment&eacute; <code>api.py</code> — application factory FastAPI</li>
+          <li><code>just serve</code> d&eacute;marre l'API, <code>just query</code> retourne des r&eacute;sultats</li>
+          <li><code>just test-all</code> passe pour tous les packages</li>
+          <li><code>just check-all</code> passe pour tous les packages</li>
+        </ul>
+      </section>
+
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/reveal.js@5/dist/reveal.js"></script>
+  <script src="https://unpkg.com/reveal.js@5/plugin/highlight/highlight.js"></script>
+  <script src="https://unpkg.com/reveal.js@5/plugin/markdown/markdown.js"></script>
+  <script src="https://unpkg.com/reveal.js@5/plugin/notes/notes.js"></script>
+  <script>
+    Reveal.initialize({
+      slideNumber: true,
+      hash: true,
+      width: 1280,
+      height: 720,
+      plugins: [RevealHighlight, RevealMarkdown, RevealNotes]
+    });
+  </script>
+</body>
+</html>

--- a/course/slides/session-3-slides.html
+++ b/course/slides/session-3-slides.html
@@ -1,0 +1,624 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Session 3 — Orchestration Kubernetes</title>
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reset.css" />
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reveal.css" />
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/theme/moon.css" />
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/plugin/highlight/monokai.css" />
+  <style>
+    .reveal pre code {
+      max-height: 500px;
+      font-size: 0.45em;
+      line-height: 1.4;
+    }
+    .reveal table {
+      font-size: 0.6em;
+    }
+    .reveal table th,
+    .reveal table td {
+      border: 1px solid #555;
+      padding: 0.3em 0.6em;
+    }
+    .reveal table thead th {
+      border-bottom: 2px solid #888;
+    }
+    .reveal li {
+      font-size: 0.75em;
+    }
+    .task-title {
+      color: #4fc3f7;
+    }
+    .reveal section img {
+      border: none;
+      box-shadow: none;
+    }
+    .reveal .small {
+      font-size: 0.55em;
+    }
+    .reveal blockquote {
+      font-size: 0.75em;
+      width: 90%;
+      padding: 0.5em 1em;
+    }
+    .reveal pre {
+      width: 100%;
+    }
+    .hint-title {
+      color: #ffd54f;
+      font-size: 0.8em;
+    }
+  </style>
+</head>
+<body>
+<div class="reveal">
+<div class="slides">
+
+<!-- ============================================================ -->
+<!-- TITLE SLIDE -->
+<!-- ============================================================ -->
+<section>
+  <h1>Session 3</h1>
+  <h2>Orchestration Kubernetes</h2>
+  <p><em>Kubeflow Pipelines sur Kind : du local au cluster</em></p>
+</section>
+
+<!-- ============================================================ -->
+<!-- PLANNING -->
+<!-- ============================================================ -->
+<section>
+  <h2>Planning</h2>
+  <table>
+    <thead>
+      <tr><th>Horaire</th><th>Activit&eacute;</th><th>Type</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0:00-0:45</td><td>Crash course Kubernetes + KFP</td><td>Cours</td></tr>
+      <tr><td>0:45-1:15</td><td>Cr&eacute;ation du cluster Kind + d&eacute;ploiement KFP</td><td>Guid&eacute;</td></tr>
+      <tr><td>1:15-1:30</td><td>Pause (KFP se d&eacute;ploie en arri&egrave;re-plan)</td><td></td></tr>
+      <tr><td>1:30-2:30</td><td>Epic 6 partie 1 : scaffold rag-pipeline, composants KFP</td><td>Hands-on</td></tr>
+      <tr><td>2:30-3:30</td><td>Epic 6 partie 2 : d&eacute;finition du pipeline, Dockerfiles</td><td>Hands-on</td></tr>
+      <tr><td>3:30-3:45</td><td>Pause</td><td></td></tr>
+      <tr><td>3:45-5:00</td><td>Epic 6 partie 3 : build images, chargement Kind, soumission</td><td>Guid&eacute;</td></tr>
+      <tr><td>5:00-5:45</td><td>Epic 7 : test d'int&eacute;gration e2e</td><td>Hands-on</td></tr>
+      <tr><td>5:45-6:30</td><td>Explorer l'interface KFP, re-lancer le pipeline</td><td>Libre</td></tr>
+      <tr><td>6:30-7:00</td><td>R&eacute;capitulatif du cours, &eacute;valuation, Q&amp;A</td><td>Cours</td></tr>
+    </tbody>
+  </table>
+  <p><strong>Livrable</strong> : le pipeline KFP s'ex&eacute;cute sur le cluster Kind, le test e2e passe, l'interface KFP affiche le run.</p>
+</section>
+
+<!-- ============================================================ -->
+<!-- CRASH COURSE KUBERNETES -->
+<!-- ============================================================ -->
+<section>
+  <h2>Crash course Kubernetes + KFP</h2>
+  <p><em>~45 min &mdash; Cours</em></p>
+</section>
+
+<!-- Kubernetes concepts essentiels -->
+<section>
+  <h3>Kubernetes &mdash; concepts essentiels</h3>
+  <table>
+    <thead>
+      <tr><th>Concept</th><th>Explication</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Pod</strong></td><td>Plus petite unit&eacute; ex&eacute;cutable. Contient un ou plusieurs conteneurs.</td></tr>
+      <tr><td><strong>Service</strong></td><td>Point d'acc&egrave;s r&eacute;seau stable vers un ensemble de pods.</td></tr>
+      <tr><td><strong>Namespace</strong></td><td>Isolation logique dans un cluster (KFP utilise <code>kubeflow</code>).</td></tr>
+      <tr><td><strong>kubectl</strong></td><td>CLI pour interagir avec le cluster.</td></tr>
+      <tr><td><strong>Kind</strong></td><td>Kubernetes IN Docker &mdash; un cluster K8s complet dans des conteneurs Docker.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- Kubernetes commandes utiles -->
+<section>
+  <h3>Commandes kubectl utiles</h3>
+  <pre><code class="language-bash" data-trim>
+kubectl get pods -n kubeflow          # voir les pods KFP
+kubectl get svc -n kubeflow           # voir les services
+kubectl logs &lt;pod-name&gt; -n kubeflow   # logs d'un pod
+kubectl describe pod &lt;name&gt; -n kubeflow  # d&eacute;tails d'un pod
+  </code></pre>
+</section>
+
+<!-- KFP concepts essentiels -->
+<section>
+  <h3>Kubeflow Pipelines &mdash; concepts essentiels</h3>
+  <table>
+    <thead>
+      <tr><th>Concept</th><th>Explication</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Component</strong></td><td>&Eacute;tape &eacute;l&eacute;mentaire = un conteneur Docker avec des entr&eacute;es/sorties.</td></tr>
+      <tr><td><strong>Pipeline</strong></td><td>Graphe acyclique de components avec d&eacute;pendances de donn&eacute;es.</td></tr>
+      <tr><td><strong>Artifact</strong></td><td>Donn&eacute;e produite par un component et consomm&eacute;e par un autre.</td></tr>
+      <tr><td><strong>Run</strong></td><td>Ex&eacute;cution d'un pipeline avec des param&egrave;tres donn&eacute;s.</td></tr>
+      <tr><td><strong>Compiler</strong></td><td>Traduit le code Python en YAML ex&eacute;cutable par KFP.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- Architecture du pipeline RAG -->
+<section>
+  <h3>Architecture du pipeline RAG</h3>
+  <pre>
+&#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;   JSON chunks   &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;
+&#x2502;  rag-loader   &#x2502;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&gt;&#x2502;  rag-embedder   &#x2502;
+&#x2502;  (chunk docs) &#x2502;   (artifact)   &#x2502;  (embed+store)  &#x2502;
+&#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;                 &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;
+                                         &#x2502; writes to
+                                         v
+                                 PostgreSQL+pgvector
+                                 (host.docker.internal:5432)
+  </pre>
+  <p>Les pods dans Kind acc&egrave;dent &agrave; PostgreSQL sur l'h&ocirc;te via <code>host.docker.internal</code>.</p>
+</section>
+
+<!-- ============================================================ -->
+<!-- CREATION DU CLUSTER KIND -->
+<!-- ============================================================ -->
+<section>
+  <h2>Cr&eacute;ation du cluster Kind</h2>
+  <p><em>~30 min &mdash; Guid&eacute;</em></p>
+  <blockquote><strong>Important</strong> : le d&eacute;ploiement de KFP prend 5-10 minutes. Lancez-le t&ocirc;t et travaillez sur le code pendant ce temps.</blockquote>
+</section>
+
+<!-- Etape 1 : Creer le cluster -->
+<section>
+  <h3 class="task-title">&Eacute;tape 1 : Cr&eacute;er le cluster</h3>
+  <pre><code class="language-bash" data-trim>
+kind create cluster --name rag-kubeflow \
+  --config infra/kind-config.yaml --wait 60s
+  </code></pre>
+  <p>V&eacute;rifier :</p>
+  <pre><code class="language-bash" data-trim>
+kubectl cluster-info
+kubectl get nodes   # doit montrer 1 n&oelig;ud "Ready"
+  </code></pre>
+</section>
+
+<!-- Etape 2 : Deployer KFP -->
+<section>
+  <h3 class="task-title">&Eacute;tape 2 : D&eacute;ployer KFP</h3>
+  <pre><code class="language-bash" data-trim>
+# Ressources cluster-scoped
+kubectl apply -k \
+  "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=2.3.0"
+kubectl wait crd/applications.app.k8s.io \
+  --for condition=established --timeout=60s
+
+# Environnement platform-agnostic
+kubectl apply -k \
+  "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=2.3.0"
+  </code></pre>
+  <p>Attendre que les pods soient pr&ecirc;ts (5-10 min) :</p>
+  <pre><code class="language-bash" data-trim>
+kubectl wait pods -l application-crd-id=kubeflow-pipelines \
+  -n kubeflow --for condition=Ready --timeout=600s
+  </code></pre>
+  <p>Ou surveiller en temps r&eacute;el :</p>
+  <pre><code class="language-bash" data-trim>
+kubectl get pods -n kubeflow -w   # Ctrl+C pour arr&ecirc;ter
+  </code></pre>
+</section>
+
+<!-- Etape 3 : Acceder a l'interface KFP -->
+<section>
+  <h3 class="task-title">&Eacute;tape 3 : Acc&eacute;der &agrave; l'interface KFP</h3>
+  <pre><code class="language-bash" data-trim>
+just kfp-ui   # port-forward vers http://localhost:8080
+  </code></pre>
+  <p>Ouvrir <code>http://localhost:8080</code> dans le navigateur.</p>
+  <blockquote><strong>Alternative rapide</strong> : <code>just infra-up</code> fait tout d'un coup (docker-compose + kind + KFP + images).</blockquote>
+</section>
+
+<!-- ============================================================ -->
+<!-- EPIC 6 — KUBEFLOW PIPELINE -->
+<!-- ============================================================ -->
+<section>
+  <h2>Epic 6 &mdash; Kubeflow Pipeline</h2>
+  <p><em>~3h30 &mdash; Hands-on + Guid&eacute;</em></p>
+</section>
+
+<!-- Tache 6.1 : Comprendre la structure -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.1 : Comprendre la structure du package</h3>
+  <pre><code data-trim>
+python/rag-pipeline/
+&#x251C;&#x2500;&#x2500; rag_pipeline/
+&#x2502;   &#x251C;&#x2500;&#x2500; __init__.py          # fourni
+&#x2502;   &#x251C;&#x2500;&#x2500; main.py              # fourni (projen)
+&#x2502;   &#x251C;&#x2500;&#x2500; task_inputs.py       # fourni
+&#x2502;   &#x251C;&#x2500;&#x2500; app.py               # &Agrave; IMPL&Eacute;MENTER
+&#x2502;   &#x251C;&#x2500;&#x2500; pipeline.py          # &Agrave; IMPL&Eacute;MENTER
+&#x2502;   &#x2514;&#x2500;&#x2500; components/
+&#x2502;       &#x251C;&#x2500;&#x2500; __init__.py      # fourni
+&#x2502;       &#x251C;&#x2500;&#x2500; loader.py        # &Agrave; IMPL&Eacute;MENTER
+&#x2502;       &#x2514;&#x2500;&#x2500; embedder.py      # &Agrave; IMPL&Eacute;MENTER
+&#x251C;&#x2500;&#x2500; tests/                   # fournis
+&#x251C;&#x2500;&#x2500; pyproject.toml           # fourni
+&#x251C;&#x2500;&#x2500; justfile                 # fourni
+&#x2514;&#x2500;&#x2500; uv.lock                  # fourni
+  </code></pre>
+</section>
+
+<!-- Tache 6.1 suite : commandes + TaskInputs -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.1 : Installer et lancer les tests</h3>
+  <pre><code class="language-bash" data-trim>
+cd python/rag-pipeline && just install-dev
+just test   # voir ce qui &eacute;choue
+  </code></pre>
+  <p><strong>TaskInputs fournis</strong> :</p>
+  <ul>
+    <li><code>pipeline_name</code> (rag-ingestion)</li>
+    <li><code>input_dir</code> (data/documents)</li>
+    <li><code>kubeflow_host</code> (http://localhost:8080)</li>
+    <li><code>compile_only</code> (False)</li>
+    <li><code>chunk_size</code> (512), <code>chunk_overlap</code> (64)</li>
+    <li><code>db_url</code>, <code>embedding_model</code>, <code>batch_size</code> (32)</li>
+  </ul>
+</section>
+
+<!-- Tache 6.2 : Composant loader -->
+<section>
+  <section>
+    <h3 class="task-title">T&acirc;che 6.2 : Impl&eacute;menter le composant loader</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-pipeline/rag_pipeline/components/loader.py</code></p>
+    <p>Un <strong>container component</strong> KFP encapsule un conteneur Docker comme &eacute;tape de pipeline.</p>
+    <pre><code class="language-python" data-trim>
+from kfp import dsl
+
+LOADER_IMAGE = "rag-loader:local"
+
+@dsl.container_component
+def loader_component(
+    input_dir: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    chunks_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+    </code></pre>
+    <p><strong>Comportement</strong> : retourner un <code>dsl.ContainerSpec</code> qui :</p>
+    <ol>
+      <li>Utilise l'image <code>rag-loader:local</code></li>
+      <li>Ex&eacute;cute la commande <code>["python", "-m", "rag_loader.main"]</code></li>
+      <li>Passe les arguments CLI : <code>--input-dir</code>, <code>--output-dir</code> (chemin de l'artifact), <code>--chunk-size</code>, <code>--chunk-overlap</code></li>
+    </ol>
+    <p><strong>V&eacute;rification</strong> :</p>
+    <pre><code class="language-bash" data-trim>
+just test -- -k test_loader   # tests doivent passer
+    </code></pre>
+  </section>
+  <!-- Hint vertical slide -->
+  <section>
+    <h4 class="hint-title">Indice : ContainerSpec</h4>
+    <pre><code class="language-python" data-trim>
+return dsl.ContainerSpec(
+    image=LOADER_IMAGE,
+    command=["python", "-m", "rag_loader.main"],
+    args=[
+        "--input-dir", input_dir,
+        "--output-dir", chunks_artifact.path,
+        "--chunk-size", str(chunk_size),
+        "--chunk-overlap", str(chunk_overlap),
+    ],
+)
+    </code></pre>
+  </section>
+</section>
+
+<!-- Tache 6.3 : Composant embedder -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.3 : Impl&eacute;menter le composant embedder</h3>
+  <p><strong>Fichier</strong> : <code>python/rag-pipeline/rag_pipeline/components/embedder.py</code></p>
+  <pre><code class="language-python" data-trim>
+from kfp import dsl
+
+EMBEDDER_IMAGE = "rag-embedder:local"
+
+@dsl.container_component
+def embedder_component(
+    chunks_artifact: dsl.Input[dsl.Artifact],
+    db_url: str,
+    embedding_model: str,
+    batch_size: int,
+    embeddings_artifact: dsl.Output[dsl.Artifact],
+) -> dsl.ContainerSpec:
+  </code></pre>
+  <p>M&ecirc;me structure que le loader : image <code>rag-embedder:local</code>, commande <code>python -m rag_embedder.main</code>, arguments CLI.</p>
+  <p><strong>V&eacute;rification</strong> :</p>
+  <pre><code class="language-bash" data-trim>
+just test -- -k test_embedder   # tests doivent passer
+  </code></pre>
+</section>
+
+<!-- Tache 6.4 : Definition du pipeline -->
+<section>
+  <section>
+    <h3 class="task-title">T&acirc;che 6.4 : Impl&eacute;menter la d&eacute;finition du pipeline</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-pipeline/rag_pipeline/pipeline.py</code></p>
+    <pre><code class="language-python" data-trim>
+from kfp import dsl
+from rag_pipeline.components.embedder import embedder_component
+from rag_pipeline.components.loader import loader_component
+
+@dsl.pipeline(
+    name="RAG Ingestion Pipeline",
+    description="Load documents, chunk, embed, and store in pgvector.",
+)
+def rag_ingestion_pipeline(
+    input_dir: str = "/data/documents",
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+    db_url: str = "postgresql+asyncpg://rag:rag@host.docker.internal:5432/rag",
+    embedding_model: str = "all-MiniLM-L6-v2",
+    batch_size: int = 32,
+) -> None:
+    </code></pre>
+    <p><strong>Comportement</strong> :</p>
+    <ol>
+      <li>Appeler <code>loader_component()</code> avec <code>input_dir</code>, <code>chunk_size</code>, <code>chunk_overlap</code></li>
+      <li>R&eacute;cup&eacute;rer l'artifact de sortie du loader (<code>chunks_artifact</code>)</li>
+      <li>Appeler <code>embedder_component()</code> avec l'artifact du loader en entr&eacute;e + <code>db_url</code>, <code>embedding_model</code>, <code>batch_size</code></li>
+    </ol>
+    <p>Le cha&icirc;nage des composants via artifacts cr&eacute;e automatiquement la d&eacute;pendance d'ex&eacute;cution.</p>
+    <p><strong>V&eacute;rification</strong> :</p>
+    <pre><code class="language-bash" data-trim>
+just test -- -k test_pipeline   # 5 tests doivent passer
+    </code></pre>
+  </section>
+  <!-- Hint vertical slide -->
+  <section>
+    <h4 class="hint-title">Indice : cha&icirc;nage des composants</h4>
+    <pre><code class="language-python" data-trim>
+loader_task = loader_component(
+    input_dir=input_dir,
+    chunk_size=chunk_size,
+    chunk_overlap=chunk_overlap,
+)
+
+embedder_component(
+    chunks_artifact=loader_task.outputs["chunks_artifact"],
+    db_url=db_url,
+    embedding_model=embedding_model,
+    batch_size=batch_size,
+)
+    </code></pre>
+  </section>
+</section>
+
+<!-- Tache 6.5 : App.run() -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.5 : Impl&eacute;menter App.run()</h3>
+  <p><strong>Fichier</strong> : <code>python/rag-pipeline/rag_pipeline/app.py</code></p>
+  <p><strong>Comportement</strong> :</p>
+  <ol>
+    <li>Afficher la configuration de <code>task_inputs</code></li>
+    <li>Compiler le pipeline en YAML avec <code>kfp.compiler.Compiler().compile()</code></li>
+    <li>Si <code>compile_only=True</code> : afficher le chemin du YAML et retourner</li>
+    <li>Sinon : cr&eacute;er un <code>kfp.client.Client(host=kubeflow_host)</code> et soumettre le pipeline</li>
+    <li>G&eacute;rer les erreurs de soumission gracieusement</li>
+  </ol>
+  <p><strong>Imports</strong> :</p>
+  <pre><code class="language-python" data-trim>
+from kfp import compiler, client
+from rag_pipeline.pipeline import rag_ingestion_pipeline
+from rag_pipeline.task_inputs import task_inputs
+  </code></pre>
+  <p><strong>V&eacute;rification</strong> :</p>
+  <pre><code class="language-bash" data-trim>
+just test -- -k test_app       # 2 tests doivent passer
+just test                       # TOUS les tests
+just check-all                  # ruff + mypy clean
+  </code></pre>
+</section>
+
+<!-- Tache 6.6 : Dockerfiles -->
+<section>
+  <section>
+    <h3 class="task-title">T&acirc;che 6.6 : Cr&eacute;er les Dockerfiles</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-loader/Dockerfile</code></p>
+    <pre><code class="language-dockerfile" data-trim>
+# --- Builder ---
+FROM python:3.13-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copier les d&eacute;pendances partag&eacute;es
+COPY python/lib-schemas python/lib-schemas
+
+# Copier le package
+COPY python/rag-loader python/rag-loader
+
+# Installer
+RUN cd python/rag-loader &amp;&amp; uv sync --no-dev --frozen
+
+# --- Runtime ---
+FROM python:3.13-slim
+COPY --from=builder /python/rag-loader/.venv /python/rag-loader/.venv
+COPY --from=builder /python/rag-loader/rag_loader /python/rag-loader/rag_loader
+COPY --from=builder /python/lib-schemas/lib_schemas /python/rag-loader/lib_schemas
+
+# Donn&eacute;es sample baked dans l'image
+COPY data/documents /data/documents
+
+ENV PATH="/python/rag-loader/.venv/bin:$PATH"
+ENTRYPOINT ["python", "-m", "rag_loader.main"]
+    </code></pre>
+  </section>
+  <section>
+    <h3 class="task-title">T&acirc;che 6.6 : Dockerfile rag-embedder</h3>
+    <p><strong>Fichier</strong> : <code>python/rag-embedder/Dockerfile</code></p>
+    <p>M&ecirc;me structure multi-stage, mais avec <strong>3 libs partag&eacute;es</strong> :</p>
+    <ul>
+      <li><code>lib-schemas</code></li>
+      <li><code>lib-embedding</code></li>
+      <li><code>lib-orm</code></li>
+    </ul>
+  </section>
+</section>
+
+<!-- Tache 6.7 : Build + chargement Kind -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.7 : Build + chargement dans Kind</h3>
+  <pre><code class="language-bash" data-trim>
+# Depuis la racine
+just build-images              # build les 3 images Docker
+just kfp-load-images           # charger loader + embedder dans Kind
+  </code></pre>
+  <p>V&eacute;rifier que les images sont dans le cluster :</p>
+  <pre><code class="language-bash" data-trim>
+docker exec rag-kubeflow-control-plane crictl images | grep rag
+  </code></pre>
+</section>
+
+<!-- Tache 6.8 : Soumettre le pipeline -->
+<section>
+  <h3 class="task-title">T&acirc;che 6.8 : Soumettre le pipeline</h3>
+  <pre><code class="language-bash" data-trim>
+# Compiler uniquement (pour v&eacute;rifier le YAML)
+cd python/rag-pipeline
+just run -- --compile-only
+
+# Soumettre au cluster (KFP UI doit &ecirc;tre accessible)
+just run
+  </code></pre>
+  <p>Ouvrir <code>http://localhost:8080</code> et observer le pipeline dans l'interface KFP :</p>
+  <ul>
+    <li>V&eacute;rifier que les deux &eacute;tapes (loader, embedder) apparaissent</li>
+    <li>Cliquer sur chaque &eacute;tape pour voir les logs</li>
+    <li>V&eacute;rifier que le run est vert (succ&egrave;s)</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- EPIC 7 — TEST E2E -->
+<!-- ============================================================ -->
+<section>
+  <h2>Epic 7 &mdash; Test d'int&eacute;gration e2e</h2>
+  <p><em>~45 min &mdash; Hands-on</em></p>
+</section>
+
+<!-- Tache 7.1 : Executer le test e2e -->
+<section>
+  <h3 class="task-title">T&acirc;che 7.1 : Ex&eacute;cuter le test e2e</h3>
+  <p>Le test d'int&eacute;gration est <strong>fourni</strong> dans <code>tests/e2e/test_full_pipeline.py</code>.</p>
+  <p>Il v&eacute;rifie le pipeline complet : load &rarr; embed &rarr; search.</p>
+  <pre><code class="language-bash" data-trim>
+# Depuis la racine (PostgreSQL doit tourner)
+just e2e
+  </code></pre>
+  <p>Le test :</p>
+  <ol>
+    <li>Ex&eacute;cute le loader sur des documents de test</li>
+    <li>Ex&eacute;cute l'embedder pour vectoriser les chunks</li>
+    <li>Lance une requ&ecirc;te de recherche via l'API</li>
+    <li>V&eacute;rifie que les r&eacute;sultats sont pertinents</li>
+  </ol>
+</section>
+
+<!-- Tache 7.2 : Deboguer -->
+<section>
+  <h3 class="task-title">T&acirc;che 7.2 : D&eacute;boguer les probl&egrave;mes &eacute;ventuels</h3>
+  <table>
+    <thead>
+      <tr><th>Probl&egrave;me</th><th>Solution</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>Connection refused</code> (DB)</td><td>V&eacute;rifier <code>docker compose ps</code> &mdash; PostgreSQL doit tourner</td></tr>
+      <tr><td><code>ImagePullBackOff</code> dans KFP</td><td>Les images ne sont pas dans Kind &rarr; <code>just kfp-load-images</code></td></tr>
+      <tr><td>Pipeline timeout</td><td>Les pods prennent du temps &agrave; d&eacute;marrer &rarr; v&eacute;rifier <code>kubectl get pods -n kubeflow</code></td></tr>
+      <tr><td><code>host.docker.internal</code> ne r&eacute;sout pas</td><td>V&eacute;rifier <code>infra/kind-config.yaml</code> &mdash; le mapping doit exister</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================ -->
+<!-- EXPLORER L'INTERFACE KFP -->
+<!-- ============================================================ -->
+<section>
+  <h2>Explorer l'interface KFP</h2>
+  <p><em>~45 min &mdash; Libre</em></p>
+</section>
+
+<section>
+  <h3>Activit&eacute;s sugg&eacute;r&eacute;es</h3>
+  <ol>
+    <li><strong>Re-lancer le pipeline</strong> avec des param&egrave;tres diff&eacute;rents (chunk_size, chunk_overlap)</li>
+    <li><strong>Explorer les artifacts</strong> : voir le JSON produit par le loader</li>
+    <li><strong>Consulter les logs</strong> de chaque &eacute;tape</li>
+    <li><strong>Comparer des runs</strong> avec des param&egrave;tres diff&eacute;rents</li>
+    <li><strong>V&eacute;rifier la base</strong> : combien de chunks apr&egrave;s un nouveau run ?</li>
+  </ol>
+  <pre><code class="language-bash" data-trim>
+docker exec -it rag-postgres psql -U rag -d rag -c \
+  "SELECT document_name, count(*) FROM document_chunks GROUP BY document_name;"
+  </code></pre>
+</section>
+
+<!-- ============================================================ -->
+<!-- RECAPITULATIF -->
+<!-- ============================================================ -->
+<section>
+  <h2>R&eacute;capitulatif Session 3 (et du cours)</h2>
+</section>
+
+<section>
+  <h3>Checklist</h3>
+  <ul>
+    <li>Cluster Kind fonctionnel avec KFP</li>
+    <li>Impl&eacute;ment&eacute; les composants KFP (loader + embedder)</li>
+    <li>Impl&eacute;ment&eacute; la d&eacute;finition du pipeline (cha&icirc;nage via artifacts)</li>
+    <li>Impl&eacute;ment&eacute; App.run() pour compiler et soumettre</li>
+    <li>Cr&eacute;&eacute; les Dockerfiles multi-stage</li>
+    <li>Charg&eacute; les images dans Kind</li>
+    <li>Soumis et ex&eacute;cut&eacute; le pipeline via KFP</li>
+    <li>Test e2e passe (<code>just e2e</code>)</li>
+    <li><code>just test-all</code> passe pour tous les packages</li>
+    <li><code>just check-all</code> passe pour tous les packages</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Ce que vous avez construit en 21 heures</h3>
+  <pre>
+Documents .md/.txt
+    &#x2502;
+    &#x25BC;
+[rag-loader]  &#x2500;&#x2500;&#x2500;&#x2500; chunk_text() &#x2500;&#x2500;&#x2500;&#x2500;&gt; chunks.json
+    &#x2502;                                      &#x2502;
+    &#x2502;              KFP Pipeline (Kind)     &#x2502;
+    &#x25BC;                                      &#x25BC;
+[rag-embedder] &#x2500;&#x2500; encode() + upsert &#x2500;&#x2500;&gt; PostgreSQL+pgvector
+                                              &#x2502;
+                                              &#x25BC;
+                                        [rag-retriever]
+                                         POST /search
+                                         FastAPI :8000
+  </pre>
+  <p>Un syst&egrave;me RAG complet, orchestr&eacute; par Kubernetes, avec tests, linting, et typage strict.</p>
+</section>
+
+</div><!-- .slides -->
+</div><!-- .reveal -->
+
+<script src="https://unpkg.com/reveal.js@5/dist/reveal.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/highlight/highlight.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/markdown/markdown.js"></script>
+<script src="https://unpkg.com/reveal.js@5/plugin/notes/notes.js"></script>
+<script>
+  Reveal.initialize({
+    slideNumber: true,
+    hash: true,
+    width: 1280,
+    height: 720,
+    plugins: [RevealHighlight, RevealMarkdown, RevealNotes],
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add self-contained reveal.js HTML slide decks for all 3 course sessions
- Full step-by-step content from session guides, converted to slides
- Dark theme (moon), code highlighting, hints as vertical slides

## Files
- `course/slides/session-1-slides.html` — Fondations (infra + libs + loader)
- `course/slides/session-2-slides.html` — Embedding et API (embedder + retriever)
- `course/slides/session-3-slides.html` — Orchestration Kubernetes (KFP + Kind + e2e)

## How to use
- Open any `.html` file in Chrome
- Navigate: arrow keys or swipe
- Print to PDF: append `?print-pdf` to URL, then Ctrl+P

## Test plan
- [ ] Open each HTML in browser — slides render correctly
- [ ] Code blocks have syntax highlighting
- [ ] Vertical slides (hints) accessible via down arrow
- [ ] `?print-pdf` produces clean PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)